### PR TITLE
build: switch to moduleResolution nodenext

### DIFF
--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -5,8 +5,8 @@ import {
   PlatformAccessory,
   Service,
 } from 'homebridge';
-import { HueSyncBoxPlatform } from '../platform';
-import { State } from '../state';
+import type { HueSyncBoxPlatform } from '../platform.js';
+import type { State } from '../state.js';
 import {
   PASSTHROUGH,
   POWER_SAVE,

--- a/src/accessories/entertainmentTv.ts
+++ b/src/accessories/entertainmentTv.ts
@@ -1,6 +1,6 @@
 import type { PlatformAccessory } from 'homebridge';
-import { HueSyncBoxPlatform } from '../platform';
-import { State } from '../state';
+import type { HueSyncBoxPlatform } from '../platform.js';
+import type { State } from '../state.js';
 import { BaseTvDevice } from './baseTv.js';
 
 export class EntertainmentTvDevice extends BaseTvDevice {

--- a/src/accessories/intensityTv.ts
+++ b/src/accessories/intensityTv.ts
@@ -1,6 +1,6 @@
 import type { CharacteristicValue, PlatformAccessory } from 'homebridge';
-import { HueSyncBoxPlatform } from '../platform';
-import { State } from '../state';
+import type { HueSyncBoxPlatform } from '../platform.js';
+import type { State } from '../state.js';
 import { BaseTvDevice } from './baseTv.js';
 
 export class IntensityTvDevice extends BaseTvDevice {

--- a/src/accessories/lightbulb.ts
+++ b/src/accessories/lightbulb.ts
@@ -1,7 +1,7 @@
 import { SyncBoxDevice } from './base.js';
 import type { PlatformAccessory } from 'homebridge';
-import { State } from '../state';
-import { HueSyncBoxPlatform } from '../platform';
+import type { State } from '../state.js';
+import type { HueSyncBoxPlatform } from '../platform.js';
 
 export class LightbulbDevice extends SyncBoxDevice {
   constructor(

--- a/src/accessories/modeTv.ts
+++ b/src/accessories/modeTv.ts
@@ -3,8 +3,8 @@ import type {
   PlatformAccessory,
   Service,
 } from 'homebridge';
-import { HueSyncBoxPlatform } from '../platform';
-import { State } from '../state';
+import type { HueSyncBoxPlatform } from '../platform.js';
+import type { State } from '../state.js';
 import { BaseTvDevice } from './baseTv.js';
 
 export class ModeTvDevice extends BaseTvDevice {

--- a/src/accessories/switch.ts
+++ b/src/accessories/switch.ts
@@ -1,7 +1,7 @@
 import type { PlatformAccessory } from 'homebridge';
 
-import { HueSyncBoxPlatform } from '../platform';
-import { State } from '../state';
+import type { HueSyncBoxPlatform } from '../platform.js';
+import type { State } from '../state.js';
 import { SyncBoxDevice } from './base.js';
 
 export class SwitchDevice extends SyncBoxDevice {

--- a/src/accessories/tv.ts
+++ b/src/accessories/tv.ts
@@ -1,6 +1,6 @@
 import { PlatformAccessory, Service } from 'homebridge';
-import { HueSyncBoxPlatform } from '../platform';
-import { HdmiInput, State } from '../state';
+import type { HueSyncBoxPlatform } from '../platform.js';
+import type { HdmiInput, State } from '../state.js';
 import { BaseTvDevice } from './baseTv.js';
 import { HDMI_INPUT_MAX, HDMI_INPUT_MIN } from '../lib/constants.js';
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -6,7 +6,7 @@ import {
   PlatformConfig,
 } from 'homebridge';
 
-import { HueSyncBoxPlatformConfig } from './config';
+import type { HueSyncBoxPlatformConfig } from './config.js';
 import { SyncBoxClient } from './lib/client.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
 import { State } from './state.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "lib": ["ES2022"],
-    "module": "ES2022",
+    "module": "nodenext",
     "target": "ES2022",
     "rootDir": "src",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "strict": true,
     "declaration": true,
     "outDir": "dist",


### PR DESCRIPTION
## Summary
Stacked on top of #378. Once #378 merges, GitHub will auto-retarget this PR's base to `main`.

This addresses the reviewer feedback on #378 — `skipLibCheck` is the right fix for upstream `.d.ts` rot, but the project should also be using `moduleResolution: "nodenext"` so that `tsc` resolves dependencies the same way Node does at runtime. Classic `node` resolution doesn't model `package.json` `imports`/`exports`, which is exactly why `@matter/general`'s `#util/*` subpath imports tripped tsc on the homebridge 2.x bump.

## Changes
- `tsconfig.json`: `moduleResolution: "node"` → `"nodenext"` and `module: "ES2022"` → `"nodenext"` (conventional pairing).
- Eight files: every relative import to a type-only symbol (`HueSyncBoxPlatform`, `State`, `HueSyncBoxPlatformConfig`, `HdmiInput`) was missing the `.js` extension. They were silently accepted under classic resolution because tsc erases type-only imports at emit. Converted them to `import type ... from "./foo.js"`, which both satisfies `nodenext`'s extension requirement and makes the type-only intent explicit. CLAUDE.md already mandates `.js` extensions for ESM, so this is just bringing the codebase back in line with that policy.

## Why both PRs are still needed
The two changes target different problems:
- `skipLibCheck` (#378) silences DOM-lib-type errors (`JsonWebKey`, `SubtleCrypto`, `AllowSharedBufferSource`, etc.) in `@matter/general`'s `.d.ts` files. These come from `lib: ["ES2022"]` not including `DOM`. Module resolution is irrelevant to this.
- `nodenext` here is correct hygiene for *our own* code — accurate type resolution for our ESM imports, with the bonus that `@matter`'s `#util/*` subpath imports would now resolve cleanly if we ever hit them directly.

## Verification
- `npm run build` (clean → test → compile → typecheck) passes locally.
- `npm run lint` passes.
- 32/32 tests pass.

## Test plan
- [ ] CI passes on this PR (Node 20.x / 22.x / 24.x build + lint)
- [ ] After #378 merges, GitHub auto-retargets this PR's base to `main` and CI re-runs green
- [ ] Smoke test the plugin against a real Sync Box / homebridge instance to confirm no runtime regression from the `module: "nodenext"` switch (CJS/ESM interop semantics differ slightly from `module: "ES2022"`)

## Follow-up (out of scope)
ts-jest emits a soft warning recommending `isolatedModules: true` whenever `module` is `nodenext`. It doesn't break the build, but is worth a small follow-up if it's safe — `isolatedModules` enforces stricter per-file compilability.