### PR TITLE
ci: serialize release runs and force atomic git pushes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
       - main
       - beta
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write # to be able to publish a GitHub release
   issues: write # to be able to comment on released issues
@@ -33,6 +37,8 @@ jobs:
           package-manager-cache: false
       - run: npm clean-install
       - run: npm audit signatures
+      - name: Configure atomic git pushes
+        run: git config --global push.atomic true
       - run: npm run semantic-release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+          # Check out the current branch tip, not github.sha. With
+          # concurrency queueing, a queued run otherwise releases its
+          # trigger SHA and is rejected as non-fast-forward once the
+          # branch has advanced. Pulling the tip turns redundant queued
+          # runs into no-ops instead.
+          ref: ${{ github.ref }}
       - uses: actions/setup-node@v6.4.0
         with:
           node-version: '24'


### PR DESCRIPTION
## Summary
- Add workflow-level `concurrency` so only one Release run executes per ref at a time (no `cancel-in-progress`, so queued runs still execute against the latest state).
- Set `push.atomic=true` in git config before `semantic-release`, so `@semantic-release/git`'s `git push --follow-tags` either lands the release commit + tag together or rolls back the tag.

## Why
On 2026-02-14 three commits hit `main` within ~10 minutes, each triggering a Release run in parallel. Without serialization, the runs raced. `@semantic-release/git` uses `git push --follow-tags` which is **not atomic** by default — when the branch push was rejected as non-fast-forward, the tag push still succeeded independently. That left three orphan tags on the remote (`v2.2.1`, `v2.2.2`, `v2.2.3`) with no corresponding commits on `main`, no npm publishes, and no GitHub releases.

Concurrency alone fixes the race. Atomic pushes are defense-in-depth for any future race (e.g. a manual push during a release) — and cheap to add. Reference: [semantic-release#2204](https://github.com/semantic-release/semantic-release/issues/2204).

## Follow-up
Orphan tags `v2.2.1`, `v2.2.2`, `v2.2.3` will be deleted from the remote separately.

## Test plan
- [ ] Merge and confirm the next Release run still publishes correctly.
- [ ] Confirm two near-simultaneous pushes to `main` queue instead of running in parallel.