### PR TITLE
ci: read DT CI key from ci/ OpenBao path (homelab Phase 3)

### DIFF
--- a/.github/workflows/pr-license-comment.yml
+++ b/.github/workflows/pr-license-comment.yml
@@ -76,7 +76,7 @@ jobs:
           role: dt-pr-license
           jwtGithubAudience: openbao
           secrets: |
-            secret/data/dependency-track/ci-api-key apiKey | DT_API_KEY
+            secret/data/ci/dependency-track/ci-api-key apiKey | DT_API_KEY
 
       - name: Upload PR SBOM and collect license policy violations
         env:


### PR DESCRIPTION
Part of the homelab OpenBao KV path consolidation (Phase 3, `ci/` domain — jabrown93/homelab#1204).

The shared Dependency-Track CI API key moves from `secret/data/dependency-track/ci-api-key` to `secret/data/ci/dependency-track/ci-api-key`. This repo's advisory PR-license check reads that key via the `dt-pr-license` OpenBao role, so its workflow needs the new path.

**Single-line change** to `.github/workflows/pr-license-comment.yml` (the OpenBao secret path). The `dt-pr-license` role + `gha-dt-sbom-upload` policy in homelab grant the new path.

**Merge after** the homelab operator has pre-copied the new path (step 1 of #1204's cutover) so the key exists when this workflow next runs. The check is advisory/non-blocking, so even out of order it cannot block a PR. Since `pr-license-comment.yml` is `workflow_run` and always runs the `main`-branch definition, this must land on `main` to take effect.