### PR TITLE
fix(security): close API server DoS, secret-leak, and validation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ a `platform` value of `PhilipsHueSyncBoxPlatform`.
 | `uuidSeed`                               | Only set this if you're running multiple instances of this plugin to differentiate the accessories. If you have existing accessories, changing this will cause them to be removed and re-created. HomeKit will consider these as new accessories and you will need to setup them up again. | string   |               | No           |                                               |
 | `apiServerEnabled`                       | Enables an HTTP API for controlling the Sync Box.                                                                                                                                                                                                                                          | boolean  | `false`       | No           |                                               |
 | `apiServerPort`                          | The port that the API (if enabled) runs on. Defaults to `40220`, please change this setting if the port is already in use.                                                                                                                                                                 | integer  | `40220`       | No           |                                               |
-| `apiServerToken`                         | The token that has to be included in each request of the API. Is required if the API is enabled and has no default value.                                                                                                                                                                  | string   |               | No           |                                               |
+| `apiServerToken`                         | The token that has to be included in each request of the API. Must be at least 32 characters long. Is required if the API is enabled and has no default value. Generate one with e.g. `openssl rand -hex 32` &mdash; do not reuse the example value below.                                 | string   |               | No           |                                               |
 
 ```json
 {
@@ -248,7 +248,7 @@ a `platform` value of `PhilipsHueSyncBoxPlatform`.
       "uuidSeed": "livingroom",
       "apiServerEnabled": false,
       "apiServerPort": 40220,
-      "apiServerToken": "token"
+      "apiServerToken": "<A-LONG-RANDOM-SECRET-AT-LEAST-32-CHARS>"
     }
   ]
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -298,8 +298,9 @@
       "apiServerToken": {
         "title": "API Token",
         "type": "string",
+        "minLength": 32,
         "required": false,
-        "description": "The token that has to be included in each request of the API. Is required if the API is enabled and has no default value."
+        "description": "The token that has to be included in each request of the API. Must be at least 32 characters long. Is required if the API is enabled and has no default value. Generate one with e.g. `openssl rand -hex 32`."
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1143,29 +1143,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -10676,10 +10653,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -16516,9 +16503,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -109,5 +109,13 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "overrides": {
+    "@nestjs/swagger": {
+      "js-yaml": "^4.2.0"
+    },
+    "homebridge-config-ui-x": {
+      "tar": "^7.5.16"
+    }
   }
 }

--- a/src/accessories/tv.ts
+++ b/src/accessories/tv.ts
@@ -16,7 +16,11 @@ export class TvDevice extends BaseTvDevice {
       .getCharacteristic(this.platform.api.hap.Characteristic.ActiveIdentifier)
       .onSet(value => {
         const identifier = value as number;
-        if (identifier < HDMI_INPUT_MIN || identifier > HDMI_INPUT_MAX) {
+        if (
+          !Number.isInteger(identifier) ||
+          identifier < HDMI_INPUT_MIN ||
+          identifier > HDMI_INPUT_MAX
+        ) {
           this.platform.log.warn(
             'Ignoring out-of-range HDMI input identifier: ' + identifier
           );

--- a/src/accessories/tv.ts
+++ b/src/accessories/tv.ts
@@ -15,8 +15,15 @@ export class TvDevice extends BaseTvDevice {
     this.service
       .getCharacteristic(this.platform.api.hap.Characteristic.ActiveIdentifier)
       .onSet(value => {
+        const identifier = value as number;
+        if (identifier < HDMI_INPUT_MIN || identifier > HDMI_INPUT_MAX) {
+          this.platform.log.warn(
+            'Ignoring out-of-range HDMI input identifier: ' + identifier
+          );
+          return;
+        }
         return this.updateExecution({
-          hdmiSource: 'input' + value,
+          hdmiSource: 'input' + identifier,
         });
       });
   }

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -1,7 +1,19 @@
 import http from 'http';
+import crypto from 'node:crypto';
 import { HueSyncBoxPlatform } from './platform.js';
 import { State } from './state.js';
-import { HTTP_STATUS_OK, HTTP_STATUS_UNAUTHORIZED } from './lib/constants.js';
+import {
+  HTTP_STATUS_OK,
+  HTTP_STATUS_UNAUTHORIZED,
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_PAYLOAD_TOO_LARGE,
+  HTTP_STATUS_METHOD_NOT_ALLOWED,
+  HTTP_STATUS_INTERNAL_ERROR,
+  MIN_API_TOKEN_LENGTH,
+  MAX_API_BODY_BYTES,
+  API_REQUEST_TIMEOUT_MS,
+} from './lib/constants.js';
+import { validateExecution, validateHue } from './lib/validation.js';
 
 export class ApiServer {
   private readonly platform: HueSyncBoxPlatform;
@@ -19,35 +31,63 @@ export class ApiServer {
       );
       return;
     }
+    if (apiServerToken.length < MIN_API_TOKEN_LENGTH) {
+      this.platform.log.error(
+        `API server cannot start: apiServerToken must be at least ${MIN_API_TOKEN_LENGTH} characters long.`
+      );
+      return;
+    }
 
     try {
       this.server = http
         .createServer((request, response) => {
-          const payload: unknown[] = [];
+          request.on('error', e =>
+            this.platform.log.error('API - Error received.', JSON.stringify(e))
+          );
+          response.on('error', () =>
+            this.platform.log.error('API - Error sending the response.')
+          );
+
+          // Authorization is checked before any body bytes are read, so an
+          // unauthenticated caller can never force the server to buffer data.
+          if (!this.isAuthorized(request, apiServerToken)) {
+            this.platform.log.debug('Authorization header missing or invalid.');
+            response.statusCode = HTTP_STATUS_UNAUTHORIZED;
+            // No 'data' listener is attached, so the request stream never
+            // resumes: any body the caller keeps sending is bounded by the
+            // OS socket receive buffer (via normal TCP flow control), not by
+            // application memory. That's what actually stops the DoS -
+            // destroying the socket here would race the response write and
+            // reset the connection before the client reads it.
+            response.end(JSON.stringify({ error: 'Unauthorized' }));
+            return;
+          }
+
+          const payload: Buffer[] = [];
+          let receivedBytes = 0;
+          let rejected = false;
 
           request
-            .on('error', e =>
-              this.platform.log.error(
-                'API - Error received.',
-                JSON.stringify(e)
-              )
-            )
-            .on('data', chunk => payload.push(chunk))
-            .on('end', async () => {
-              response.on('error', () =>
-                this.platform.log.error('API - Error sending the response.')
-              );
-
-              if (request.headers['authorization'] !== apiServerToken) {
-                this.platform.log.debug(
-                  'Authorization header missing or invalid.'
-                );
-                response.statusCode = HTTP_STATUS_UNAUTHORIZED;
-                response.write(JSON.stringify({ error: 'Unauthorized' }));
-                response.end();
+            .on('data', (chunk: Buffer) => {
+              if (rejected) {
                 return;
               }
-
+              receivedBytes += chunk.length;
+              if (receivedBytes > MAX_API_BODY_BYTES) {
+                rejected = true;
+                response.statusCode = HTTP_STATUS_PAYLOAD_TOO_LARGE;
+                // Remaining chunks are still drained (and discarded) by this
+                // same 'data' handler rather than buffered, bounding memory;
+                // the server's requestTimeout bounds how long that continues.
+                response.end(JSON.stringify({ error: 'Payload too large.' }));
+                return;
+              }
+              payload.push(chunk);
+            })
+            .on('end', async () => {
+              if (rejected) {
+                return;
+              }
               switch (request.method) {
                 case 'GET':
                   await this.handleGet(response);
@@ -57,16 +97,33 @@ export class ApiServer {
                   break;
                 default:
                   this.platform.log.debug('No action matched.');
-                  response.statusCode = 405;
+                  response.statusCode = HTTP_STATUS_METHOD_NOT_ALLOWED;
                   response.end();
               }
             });
         })
         .listen(apiServerPort, '0.0.0.0');
+      this.server.requestTimeout = API_REQUEST_TIMEOUT_MS;
     } catch (e) {
       this.platform.log.error('API could not be started: ' + JSON.stringify(e));
     }
     this.platform.log.info('API server started.');
+  }
+
+  private isAuthorized(
+    request: http.IncomingMessage,
+    apiServerToken: string
+  ): boolean {
+    const provided = request.headers['authorization'];
+    if (typeof provided !== 'string') {
+      return false;
+    }
+    const providedBuffer = Buffer.from(provided);
+    const tokenBuffer = Buffer.from(apiServerToken);
+    if (providedBuffer.length !== tokenBuffer.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(providedBuffer, tokenBuffer);
   }
 
   private async handleGet(response: http.ServerResponse) {
@@ -78,7 +135,7 @@ export class ApiServer {
       response.statusCode = HTTP_STATUS_OK;
     } catch (e) {
       this.platform.log.error('Error while getting the state.', e);
-      response.statusCode = 500;
+      response.statusCode = HTTP_STATUS_INTERNAL_ERROR;
       response.write(
         JSON.stringify({
           error: 'An error occurred while processing your request.',
@@ -89,35 +146,62 @@ export class ApiServer {
     }
   }
 
-  private async handlePost(payload: unknown[], response: http.ServerResponse) {
+  private async handlePost(payload: Buffer[], response: http.ServerResponse) {
     if (!payload.length) {
-      response.statusCode = 400;
+      response.statusCode = HTTP_STATUS_BAD_REQUEST;
       response.write(JSON.stringify({ error: 'Body missing.' }));
       response.end();
       return;
     }
 
-    let body: State;
+    let body: Partial<State>;
     try {
-      body = JSON.parse(Buffer.concat(payload as Uint8Array[]).toString());
+      body = JSON.parse(Buffer.concat(payload).toString());
       if (!body) {
         // noinspection ExceptionCaughtLocallyJS
         throw new Error('Body missing.');
       }
     } catch (e) {
       this.platform.log.error('Body malformed.', e);
-      response.statusCode = 400;
+      response.statusCode = HTTP_STATUS_BAD_REQUEST;
       response.write(JSON.stringify({ error: 'Body malformed.' }));
       response.end();
       return;
     }
 
-    try {
-      if (body.execution) {
-        await this.platform.client.updateExecution(body.execution);
+    let execution;
+    if (body.execution) {
+      const result = validateExecution(body.execution);
+      if (!result.ok) {
+        response.statusCode = HTTP_STATUS_BAD_REQUEST;
+        response.write(JSON.stringify({ error: result.error }));
+        response.end();
+        return;
       }
-      if (body.hue) {
-        await this.platform.client.updateHue(body.hue);
+      execution = result.value;
+    }
+
+    let hue;
+    if (body.hue) {
+      // Validated against live device state so only a groupId that actually
+      // exists can be forwarded.
+      const currentState = await this.platform.client.getState();
+      const result = validateHue(body.hue, currentState);
+      if (!result.ok) {
+        response.statusCode = HTTP_STATUS_BAD_REQUEST;
+        response.write(JSON.stringify({ error: result.error }));
+        response.end();
+        return;
+      }
+      hue = result.value;
+    }
+
+    try {
+      if (execution) {
+        await this.platform.client.updateExecution(execution);
+      }
+      if (hue) {
+        await this.platform.client.updateHue(hue);
       }
 
       const newState = await this.platform.client.getState();
@@ -125,7 +209,7 @@ export class ApiServer {
       response.write(JSON.stringify(newState));
     } catch (e) {
       this.platform.log.error('Error while updating the state.', e);
-      response.statusCode = 500;
+      response.statusCode = HTTP_STATUS_INTERNAL_ERROR;
       response.write(
         JSON.stringify({
           error: 'An error occurred while processing your request.',

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -1,7 +1,6 @@
 import http from 'http';
 import crypto from 'node:crypto';
 import { HueSyncBoxPlatform } from './platform.js';
-import { State } from './state.js';
 import {
   HTTP_STATUS_OK,
   HTTP_STATUS_UNAUTHORIZED,
@@ -13,7 +12,11 @@ import {
   MAX_API_BODY_BYTES,
   API_REQUEST_TIMEOUT_MS,
 } from './lib/constants.js';
-import { validateExecution, validateHue } from './lib/validation.js';
+import {
+  isPlainObject,
+  validateExecution,
+  validateHue,
+} from './lib/validation.js';
 
 export class ApiServer {
   private readonly platform: HueSyncBoxPlatform;
@@ -42,7 +45,7 @@ export class ApiServer {
       this.server = http
         .createServer((request, response) => {
           request.on('error', e =>
-            this.platform.log.error('API - Error received.', JSON.stringify(e))
+            this.platform.log.error('API - Error received.', e)
           );
           response.on('error', () =>
             this.platform.log.error('API - Error sending the response.')
@@ -105,7 +108,7 @@ export class ApiServer {
         .listen(apiServerPort, '0.0.0.0');
       this.server.requestTimeout = API_REQUEST_TIMEOUT_MS;
     } catch (e) {
-      this.platform.log.error('API could not be started: ' + JSON.stringify(e));
+      this.platform.log.error('API could not be started:', e);
     }
     this.platform.log.info('API server started.');
   }
@@ -154,13 +157,9 @@ export class ApiServer {
       return;
     }
 
-    let body: Partial<State>;
+    let body: unknown;
     try {
       body = JSON.parse(Buffer.concat(payload).toString());
-      if (!body) {
-        // noinspection ExceptionCaughtLocallyJS
-        throw new Error('Body missing.');
-      }
     } catch (e) {
       this.platform.log.error('Body malformed.', e);
       response.statusCode = HTTP_STATUS_BAD_REQUEST;
@@ -169,8 +168,15 @@ export class ApiServer {
       return;
     }
 
+    if (!isPlainObject(body)) {
+      response.statusCode = HTTP_STATUS_BAD_REQUEST;
+      response.write(JSON.stringify({ error: 'Body must be a JSON object.' }));
+      response.end();
+      return;
+    }
+
     let execution;
-    if (body.execution) {
+    if (Object.hasOwn(body, 'execution')) {
       const result = validateExecution(body.execution);
       if (!result.ok) {
         response.statusCode = HTTP_STATUS_BAD_REQUEST;
@@ -182,7 +188,7 @@ export class ApiServer {
     }
 
     let hue;
-    if (body.hue) {
+    if (Object.hasOwn(body, 'hue')) {
       // Validated against live device state so only a groupId that actually
       // exists can be forwarded.
       const currentState = await this.platform.client.getState();

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -84,7 +84,14 @@ export class SyncBoxClient {
       agent: new https.Agent({ rejectUnauthorized: false, keepAlive: true }),
     };
 
-    this.log.debug('Request to Sync Box:', url, JSON.stringify(options));
+    this.log.debug(
+      'Request to Sync Box:',
+      url,
+      JSON.stringify({
+        ...options,
+        headers: { ...options.headers, Authorization: '[REDACTED]' },
+      })
+    );
 
     const res = await fetch(url, options);
     if (!res.ok) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -48,3 +48,24 @@ export const HTTP_RETRY_COUNT = 3;
 export const HTTP_RETRY_BASE_DELAY_MS = 1000;
 export const HTTP_STATUS_OK = 200;
 export const HTTP_STATUS_UNAUTHORIZED = 401;
+export const HTTP_STATUS_BAD_REQUEST = 400;
+export const HTTP_STATUS_PAYLOAD_TOO_LARGE = 413;
+export const HTTP_STATUS_METHOD_NOT_ALLOWED = 405;
+export const HTTP_STATUS_INTERNAL_ERROR = 500;
+
+// ===== Intensity Constants =====
+export const VALID_INTENSITIES: string[] = [
+  'subtle',
+  'moderate',
+  'high',
+  'intense',
+];
+
+// ===== API Server Security Constants =====
+// Minimum length required for apiServerToken before the API server will start.
+export const MIN_API_TOKEN_LENGTH = 32;
+// Legitimate execution/hue payloads are a few hundred bytes; this caps request
+// bodies well above that while still bounding memory use per connection.
+export const MAX_API_BODY_BYTES = 100_000;
+// No legitimate request to this API should take anywhere near this long.
+export const API_REQUEST_TIMEOUT_MS = 10_000;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -26,7 +26,9 @@ const HDMI_SOURCE_PATTERN = new RegExp(
   `^input[${HDMI_INPUT_MIN}-${HDMI_INPUT_MAX}]$`
 );
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
+export function isPlainObject(
+  value: unknown
+): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
@@ -56,6 +58,66 @@ function validateIntensityPayload(
   return { ok: true, value: { intensity: value.intensity } };
 }
 
+function validateModeField(value: unknown): ValidationResult<Execution> {
+  if (typeof value !== 'string' || !VALID_EXECUTION_MODES.includes(value)) {
+    return {
+      ok: false,
+      error: `execution.mode must be one of: ${VALID_EXECUTION_MODES.join(', ')}.`,
+    };
+  }
+  return { ok: true, value: { mode: value } };
+}
+
+function validateBrightnessField(value: unknown): ValidationResult<Execution> {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < BRIGHTNESS_MIN ||
+    value > BRIGHTNESS_MAX_SYNCBOX
+  ) {
+    return {
+      ok: false,
+      error: `execution.brightness must be a number between ${BRIGHTNESS_MIN} and ${BRIGHTNESS_MAX_SYNCBOX}.`,
+    };
+  }
+  return { ok: true, value: { brightness: value } };
+}
+
+function validateHdmiSourceField(value: unknown): ValidationResult<Execution> {
+  if (typeof value !== 'string' || !HDMI_SOURCE_PATTERN.test(value)) {
+    return {
+      ok: false,
+      error: `execution.hdmiSource must match input${HDMI_INPUT_MIN} through input${HDMI_INPUT_MAX}.`,
+    };
+  }
+  return { ok: true, value: { hdmiSource: value } };
+}
+
+function validateExecutionField(
+  key: string,
+  value: unknown
+): ValidationResult<Execution> {
+  switch (key) {
+    case 'mode':
+      return validateModeField(value);
+    case 'brightness':
+      return validateBrightnessField(value);
+    case 'hdmiSource':
+      return validateHdmiSourceField(value);
+    case 'video':
+    case 'game':
+    case 'music': {
+      const result = validateIntensityPayload(value, `execution.${key}`);
+      return result.ok ? { ok: true, value: { [key]: result.value } } : result;
+    }
+    default:
+      return {
+        ok: false,
+        error: `execution.${key} is not a recognized or settable field.`,
+      };
+  }
+}
+
 /**
  * Applies the same bounds/allowlist checks the HomeKit-driven accessory code applies
  * before calling SyncBoxClient.updateExecution, so the API server can't be used to send
@@ -69,64 +131,11 @@ export function validateExecution(input: unknown): ValidationResult<Execution> {
   const value: Record<string, unknown> = {};
 
   for (const key of Object.keys(input)) {
-    switch (key) {
-      case 'mode': {
-        const mode = input.mode;
-        if (typeof mode !== 'string' || !VALID_EXECUTION_MODES.includes(mode)) {
-          return {
-            ok: false,
-            error: `execution.mode must be one of: ${VALID_EXECUTION_MODES.join(', ')}.`,
-          };
-        }
-        value.mode = mode;
-        break;
-      }
-      case 'brightness': {
-        const brightness = input.brightness;
-        if (
-          typeof brightness !== 'number' ||
-          !Number.isFinite(brightness) ||
-          brightness < BRIGHTNESS_MIN ||
-          brightness > BRIGHTNESS_MAX_SYNCBOX
-        ) {
-          return {
-            ok: false,
-            error: `execution.brightness must be a number between ${BRIGHTNESS_MIN} and ${BRIGHTNESS_MAX_SYNCBOX}.`,
-          };
-        }
-        value.brightness = brightness;
-        break;
-      }
-      case 'hdmiSource': {
-        const hdmiSource = input.hdmiSource;
-        if (
-          typeof hdmiSource !== 'string' ||
-          !HDMI_SOURCE_PATTERN.test(hdmiSource)
-        ) {
-          return {
-            ok: false,
-            error: `execution.hdmiSource must match input${HDMI_INPUT_MIN} through input${HDMI_INPUT_MAX}.`,
-          };
-        }
-        value.hdmiSource = hdmiSource;
-        break;
-      }
-      case 'video':
-      case 'game':
-      case 'music': {
-        const result = validateIntensityPayload(input[key], `execution.${key}`);
-        if (!result.ok) {
-          return result;
-        }
-        value[key] = result.value;
-        break;
-      }
-      default:
-        return {
-          ok: false,
-          error: `execution.${key} is not a recognized or settable field.`,
-        };
+    const result = validateExecutionField(key, input[key]);
+    if (!result.ok) {
+      return result;
     }
+    Object.assign(value, result.value);
   }
 
   if (Object.keys(value).length === 0) {
@@ -161,10 +170,7 @@ export function validateHue(
     return { ok: false, error: 'hue.groupId must be a non-empty string.' };
   }
 
-  if (
-    !state?.hue?.groups ||
-    !Object.prototype.hasOwnProperty.call(state.hue.groups, groupId)
-  ) {
+  if (!state?.hue?.groups || !Object.hasOwn(state.hue.groups, groupId)) {
     return {
       ok: false,
       error: 'hue.groupId does not match a known entertainment area.',

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -13,8 +13,7 @@ import {
 } from './constants.js';
 
 export type ValidationResult<T> =
-  | { ok: true; value: Partial<T> }
-  | { ok: false; error: string };
+  { ok: true; value: Partial<T> } | { ok: false; error: string };
 
 const VALID_EXECUTION_MODES: string[] = [
   MODE_VIDEO,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,176 @@
+import { Execution, Hue, State } from '../state.js';
+import {
+  MODE_VIDEO,
+  MODE_MUSIC,
+  MODE_GAME,
+  PASSTHROUGH,
+  POWER_SAVE,
+  BRIGHTNESS_MIN,
+  BRIGHTNESS_MAX_SYNCBOX,
+  HDMI_INPUT_MIN,
+  HDMI_INPUT_MAX,
+  VALID_INTENSITIES,
+} from './constants.js';
+
+export type ValidationResult<T> =
+  | { ok: true; value: Partial<T> }
+  | { ok: false; error: string };
+
+const VALID_EXECUTION_MODES: string[] = [
+  MODE_VIDEO,
+  MODE_MUSIC,
+  MODE_GAME,
+  PASSTHROUGH,
+  POWER_SAVE,
+];
+const HDMI_SOURCE_PATTERN = new RegExp(
+  `^input[${HDMI_INPUT_MIN}-${HDMI_INPUT_MAX}]$`
+);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateIntensityPayload(
+  value: unknown,
+  field: string
+): ValidationResult<{ intensity: string }> {
+  if (!isPlainObject(value)) {
+    return { ok: false, error: `${field} must be an object.` };
+  }
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || keys[0] !== 'intensity') {
+    return {
+      ok: false,
+      error: `${field} may only contain an 'intensity' field.`,
+    };
+  }
+  if (
+    typeof value.intensity !== 'string' ||
+    !VALID_INTENSITIES.includes(value.intensity)
+  ) {
+    return {
+      ok: false,
+      error: `${field}.intensity must be one of: ${VALID_INTENSITIES.join(', ')}.`,
+    };
+  }
+  return { ok: true, value: { intensity: value.intensity } };
+}
+
+/**
+ * Applies the same bounds/allowlist checks the HomeKit-driven accessory code applies
+ * before calling SyncBoxClient.updateExecution, so the API server can't be used to send
+ * values no legitimate code path would ever produce.
+ */
+export function validateExecution(input: unknown): ValidationResult<Execution> {
+  if (!isPlainObject(input)) {
+    return { ok: false, error: 'execution must be an object.' };
+  }
+
+  const value: Record<string, unknown> = {};
+
+  for (const key of Object.keys(input)) {
+    switch (key) {
+      case 'mode': {
+        const mode = input.mode;
+        if (typeof mode !== 'string' || !VALID_EXECUTION_MODES.includes(mode)) {
+          return {
+            ok: false,
+            error: `execution.mode must be one of: ${VALID_EXECUTION_MODES.join(', ')}.`,
+          };
+        }
+        value.mode = mode;
+        break;
+      }
+      case 'brightness': {
+        const brightness = input.brightness;
+        if (
+          typeof brightness !== 'number' ||
+          !Number.isFinite(brightness) ||
+          brightness < BRIGHTNESS_MIN ||
+          brightness > BRIGHTNESS_MAX_SYNCBOX
+        ) {
+          return {
+            ok: false,
+            error: `execution.brightness must be a number between ${BRIGHTNESS_MIN} and ${BRIGHTNESS_MAX_SYNCBOX}.`,
+          };
+        }
+        value.brightness = brightness;
+        break;
+      }
+      case 'hdmiSource': {
+        const hdmiSource = input.hdmiSource;
+        if (
+          typeof hdmiSource !== 'string' ||
+          !HDMI_SOURCE_PATTERN.test(hdmiSource)
+        ) {
+          return {
+            ok: false,
+            error: `execution.hdmiSource must match input${HDMI_INPUT_MIN} through input${HDMI_INPUT_MAX}.`,
+          };
+        }
+        value.hdmiSource = hdmiSource;
+        break;
+      }
+      case 'video':
+      case 'game':
+      case 'music': {
+        const result = validateIntensityPayload(input[key], `execution.${key}`);
+        if (!result.ok) {
+          return result;
+        }
+        value[key] = result.value;
+        break;
+      }
+      default:
+        return {
+          ok: false,
+          error: `execution.${key} is not a recognized or settable field.`,
+        };
+    }
+  }
+
+  if (Object.keys(value).length === 0) {
+    return {
+      ok: false,
+      error: 'execution must contain at least one recognized field.',
+    };
+  }
+
+  return { ok: true, value: value as Partial<Execution> };
+}
+
+/**
+ * Mirrors EntertainmentTvDevice's group-existence check: only a groupId that exists in
+ * the device's current state may be forwarded to SyncBoxClient.updateHue.
+ */
+export function validateHue(
+  input: unknown,
+  state: State | null
+): ValidationResult<Hue> {
+  if (!isPlainObject(input)) {
+    return { ok: false, error: 'hue must be an object.' };
+  }
+
+  const keys = Object.keys(input);
+  if (keys.length !== 1 || keys[0] !== 'groupId') {
+    return { ok: false, error: 'hue may only contain a groupId field.' };
+  }
+
+  const groupId = input.groupId;
+  if (typeof groupId !== 'string' || !groupId) {
+    return { ok: false, error: 'hue.groupId must be a non-empty string.' };
+  }
+
+  if (
+    !state?.hue?.groups ||
+    !Object.prototype.hasOwnProperty.call(state.hue.groups, groupId)
+  ) {
+    return {
+      ok: false,
+      error: 'hue.groupId does not match a known entertainment area.',
+    };
+  }
+
+  return { ok: true, value: { groupId } };
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -136,6 +136,23 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
       this.config.entertainmentTvAccessoryLightbulb ?? false;
   }
 
+  // Omits WiFi SSID and LAN IP addresses from debug output, since debug logs are
+  // routinely pasted into public support requests/issues.
+  private redactStateForLogging(state: State): unknown {
+    return {
+      ...state,
+      device: {
+        ...state.device,
+        ipAddress: '[REDACTED]',
+        wifi: { ...state.device.wifi, ssid: '[REDACTED]' },
+      },
+      hue: {
+        ...state.hue,
+        bridgeIpAddress: '[REDACTED]',
+      },
+    };
+  }
+
   configureAccessory(accessory: PlatformAccessory) {
     this.log.info('Loading accessory from cache:', accessory.context.kind);
     this.existingAccessories.set(accessory.UUID, accessory);
@@ -149,7 +166,7 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
           'ensure the sync box is online and the API token is correct and restart the plugin.'
       );
     }
-    this.log.debug('Discovered state:', state);
+    this.log.debug('Discovered state:', this.redactStateForLogging(state));
     const accessories = this.discoverAccessories(state);
     const uuids = accessories.map(accessory => {
       const uuid = accessory.UUID; // see if an accessory with the same uuid has already been registered and restored from

--- a/test/unit/lib/validation.test.ts
+++ b/test/unit/lib/validation.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from '@jest/globals';
+import { validateExecution, validateHue } from '../../../src/lib/validation.js';
+import { State } from '../../../src/state.js';
+
+function makeState(groups: Record<string, { name: string }>): State {
+  return {
+    hue: {
+      bridgeUniqueId: 'bridge-1',
+      bridgeIpAddress: '10.0.0.5',
+      groupId: '',
+      groups: groups as State['hue']['groups'],
+      connectionState: 'linked',
+    },
+  } as State;
+}
+
+describe('validateExecution', () => {
+  it('accepts a valid mode', () => {
+    const result = validateExecution({ mode: 'video' });
+    expect(result).toEqual({ ok: true, value: { mode: 'video' } });
+  });
+
+  it('rejects an unrecognized mode', () => {
+    const result = validateExecution({ mode: 'literally-anything' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts brightness within range', () => {
+    const result = validateExecution({ brightness: 150 });
+    expect(result).toEqual({ ok: true, value: { brightness: 150 } });
+  });
+
+  it('rejects negative brightness', () => {
+    const result = validateExecution({ brightness: -99999 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects brightness above the Sync Box max', () => {
+    const result = validateExecution({ brightness: 201 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-finite brightness', () => {
+    expect(validateExecution({ brightness: Infinity }).ok).toBe(false);
+    expect(validateExecution({ brightness: NaN }).ok).toBe(false);
+  });
+
+  it('accepts a well-formed hdmiSource', () => {
+    const result = validateExecution({ hdmiSource: 'input2' });
+    expect(result).toEqual({ ok: true, value: { hdmiSource: 'input2' } });
+  });
+
+  it('rejects an out-of-range or malformed hdmiSource', () => {
+    expect(validateExecution({ hdmiSource: 'input999999999' }).ok).toBe(false);
+    expect(validateExecution({ hdmiSource: 'anything' }).ok).toBe(false);
+  });
+
+  it('accepts a valid video intensity payload', () => {
+    const result = validateExecution({ video: { intensity: 'high' } });
+    expect(result).toEqual({
+      ok: true,
+      value: { video: { intensity: 'high' } },
+    });
+  });
+
+  it('rejects an invalid intensity value', () => {
+    const result = validateExecution({ video: { intensity: 'extreme' } });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects extra fields inside a mode sub-object', () => {
+    const result = validateExecution({
+      video: { intensity: 'high', backgroundLighting: true },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects unrecognized top-level fields', () => {
+    const result = validateExecution({ hueTarget: 'somewhere' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(validateExecution('video').ok).toBe(false);
+    expect(validateExecution(null).ok).toBe(false);
+    expect(validateExecution([1, 2, 3]).ok).toBe(false);
+  });
+
+  it('rejects an empty object', () => {
+    expect(validateExecution({}).ok).toBe(false);
+  });
+
+  it('accepts multiple valid fields together', () => {
+    const result = validateExecution({ mode: 'game', brightness: 100 });
+    expect(result).toEqual({
+      ok: true,
+      value: { mode: 'game', brightness: 100 },
+    });
+  });
+});
+
+describe('validateHue', () => {
+  it('accepts a groupId that exists in the current state', () => {
+    const state = makeState({ 'group-1': { name: 'Living Room' } });
+    const result = validateHue({ groupId: 'group-1' }, state);
+    expect(result).toEqual({ ok: true, value: { groupId: 'group-1' } });
+  });
+
+  it('rejects a groupId that does not exist in the current state', () => {
+    const state = makeState({ 'group-1': { name: 'Living Room' } });
+    const result = validateHue({ groupId: 'unknown-group' }, state);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects when state is null', () => {
+    const result = validateHue({ groupId: 'group-1' }, null);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a non-string groupId', () => {
+    const state = makeState({ 'group-1': { name: 'Living Room' } });
+    expect(validateHue({ groupId: 123 }, state).ok).toBe(false);
+  });
+
+  it('rejects extra fields', () => {
+    const state = makeState({ 'group-1': { name: 'Living Room' } });
+    const result = validateHue(
+      { groupId: 'group-1', somethingElse: true },
+      state
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(validateHue('group-1', null).ok).toBe(false);
+  });
+});

--- a/test/unit/lib/validation.test.ts
+++ b/test/unit/lib/validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from '@jest/globals';
-import { validateExecution, validateHue } from '../../../src/lib/validation.js';
+import {
+  isPlainObject,
+  validateExecution,
+  validateHue,
+} from '../../../src/lib/validation.js';
 import { State } from '../../../src/state.js';
 
 function makeState(groups: Record<string, { name: string }>): State {
@@ -13,6 +17,21 @@ function makeState(groups: Record<string, { name: string }>): State {
     },
   } as State;
 }
+
+describe('isPlainObject', () => {
+  it('accepts plain objects', () => {
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject({ a: 1 })).toBe(true);
+  });
+
+  it('rejects arrays, null, and primitives', () => {
+    expect(isPlainObject([1, 2, 3])).toBe(false);
+    expect(isPlainObject(null)).toBe(false);
+    expect(isPlainObject('a string')).toBe(false);
+    expect(isPlainObject(42)).toBe(false);
+    expect(isPlainObject(undefined)).toBe(false);
+  });
+});
 
 describe('validateExecution', () => {
   it('accepts a valid mode', () => {


### PR DESCRIPTION
## Summary

Fixes the findings from an adversarial security audit of this repo (1 HIGH, 3 MEDIUM, plus the report's hardening notes), plus the 2 open Dependabot alerts flagged when this branch was first pushed. All application-code changes are scoped to the optional `apiServerEnabled` HTTP automation API and the Sync Box client's debug logging - nothing here changes default (API-server-disabled) behavior.

### Application code

- **HIGH - Unauthenticated memory-exhaustion DoS**: `ApiServer` buffered a caller's entire request body into memory *before* checking the `Authorization` header, so any host that could reach the port could crash the whole Homebridge process (not just this plugin) with an unterminated request and zero credentials. Auth is now checked before any body listener is attached; authenticated bodies are capped at 100KB and the server sets an explicit 10s `requestTimeout`.
- **MEDIUM - Bearer token in debug logs**: `SyncBoxClient.sendRequest` logged the full request `options` object - including the live `Authorization: Bearer <token>` header - at debug level on every request. This project's own issue templates ask users to paste debug logs when filing issues. The header is now redacted before logging.
- **MEDIUM - No brute-force protection on `apiServerToken`**: the token comparison had no rate limiting and no minimum length, and the README's own example value was the literal string `"token"`. `apiServerToken` now must be >= 32 chars (the server refuses to start otherwise, same pattern as the existing missing-config guard) and is compared with `crypto.timingSafeEqual`.
- **MEDIUM - API-server pass-through bypassed the plugin's own validation**: `handlePost` forwarded `body.execution`/`body.hue` straight to the device with no bounds/allowlist checks, unlike every HomeKit-driven code path that reaches the same client methods (brightness clamping, mode/intensity allowlists, Hue-group existence checks). New `src/lib/validation.ts` applies the same checks to the API server; a request with any unrecognized or out-of-range field now gets a 400 instead of being forwarded.
- **Hardening**: bounds-check the HDMI `ActiveIdentifier` in `tv.ts` (its three sibling TV accessory classes already do this); redact WiFi SSID / LAN IPs from the periodic debug state dump; require a real random token in the schema/README instead of the example `"token"`.

### Dependencies

- **2 open moderate Dependabot alerts**: `js-yaml@4.1.1` (quadratic-complexity DoS, GHSA-h67p-54hq-rp68) pulled in via `@nestjs/swagger`, and `tar@7.5.15` (PAX header parser differential / file smuggling, GHSA-vmf3-w455-68vh) pulled in via `homebridge-config-ui-x`. Both are `devDependencies` only - neither ships in the published npm package - but `npm audit fix` couldn't resolve them because both parents pin an exact vulnerable version rather than a range. Added scoped `package.json` `overrides` forcing just those two resolution paths to patched versions, without touching the unrelated `js-yaml@3.15.0` copy used by `@istanbuljs/load-nyc-config` (a blanket override would've force-upgraded that across a major version for no security benefit). `npm audit` now reports 0 vulnerabilities.

## Test plan

- [x] `npm run typecheck` / `npm run lint` / `npm run prettier` / `npm run build` all pass
- [x] `npm test` - 53 tests pass, including 21 new tests for `src/lib/validation.ts` covering valid/invalid mode, brightness bounds, hdmiSource format, intensity sub-objects, and hue.groupId existence checks
- [x] Manually reproduced the original DoS against the compiled server: an unauthenticated client streaming an unterminated 20MB chunked body now gets an immediate `401` (before finishing the stream) instead of the server buffering indefinitely
- [x] Smoke-tested the API server end-to-end against a fake platform/client: unauthorized GET/POST, valid GET, valid POST with good/bad `execution` and `hue` payloads, and an oversized-body rejection (413) - all behave as expected
- [x] `npm audit` clean after the dependency overrides; confirmed via lockfile inspection that only the two flagged resolution paths moved versions

https://claude.ai/code/session_01XFTyCpHzsC78AriZU2F1T5