### PR TITLE
fix(security): prevent process-wide crashes from api-server and Sync Box response handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2907,6 +2907,29 @@
         }
       }
     },
+    "node_modules/@nestjs/swagger/node_modules/js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "node_modules/@nestjs/websockets": {
       "version": "11.1.24",
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.24.tgz",
@@ -10651,6 +10674,29 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -28,84 +28,93 @@ export class ApiServer {
 
   public start() {
     const { apiServerPort, apiServerToken } = this.platform.config;
-    if (!apiServerPort || !apiServerToken) {
+    if (!apiServerPort) {
       this.platform.log.error(
         'API server cannot start due to missing configuration.'
       );
       return;
     }
-    if (apiServerToken.length < MIN_API_TOKEN_LENGTH) {
+    if (
+      typeof apiServerToken !== 'string' ||
+      apiServerToken.length < MIN_API_TOKEN_LENGTH
+    ) {
       this.platform.log.error(
-        `API server cannot start: apiServerToken must be at least ${MIN_API_TOKEN_LENGTH} characters long.`
+        `API server cannot start: apiServerToken must be a string at least ${MIN_API_TOKEN_LENGTH} characters long.`
       );
       return;
     }
 
     try {
-      this.server = http
-        .createServer((request, response) => {
-          request.on('error', e =>
-            this.platform.log.error('API - Error received.', e)
-          );
-          response.on('error', () =>
-            this.platform.log.error('API - Error sending the response.')
-          );
+      this.server = http.createServer((request, response) => {
+        request.on('error', e =>
+          this.platform.log.error('API - Error received.', e)
+        );
+        response.on('error', () =>
+          this.platform.log.error('API - Error sending the response.')
+        );
 
-          // Authorization is checked before any body bytes are read, so an
-          // unauthenticated caller can never force the server to buffer data.
-          if (!this.isAuthorized(request, apiServerToken)) {
-            this.platform.log.debug('Authorization header missing or invalid.');
-            response.statusCode = HTTP_STATUS_UNAUTHORIZED;
-            // No 'data' listener is attached, so the request stream never
-            // resumes: any body the caller keeps sending is bounded by the
-            // OS socket receive buffer (via normal TCP flow control), not by
-            // application memory. That's what actually stops the DoS -
-            // destroying the socket here would race the response write and
-            // reset the connection before the client reads it.
-            response.end(JSON.stringify({ error: 'Unauthorized' }));
-            return;
-          }
+        // Authorization is checked before any body bytes are read, so an
+        // unauthenticated caller can never force the server to buffer data.
+        if (!this.isAuthorized(request, apiServerToken)) {
+          this.platform.log.debug('Authorization header missing or invalid.');
+          response.statusCode = HTTP_STATUS_UNAUTHORIZED;
+          // No 'data' listener is attached, so the request stream never
+          // resumes: any body the caller keeps sending is bounded by the
+          // OS socket receive buffer (via normal TCP flow control), not by
+          // application memory. That's what actually stops the DoS -
+          // destroying the socket here would race the response write and
+          // reset the connection before the client reads it.
+          response.end(JSON.stringify({ error: 'Unauthorized' }));
+          return;
+        }
 
-          const payload: Buffer[] = [];
-          let receivedBytes = 0;
-          let rejected = false;
+        const payload: Buffer[] = [];
+        let receivedBytes = 0;
+        let rejected = false;
 
-          request
-            .on('data', (chunk: Buffer) => {
-              if (rejected) {
-                return;
-              }
-              receivedBytes += chunk.length;
-              if (receivedBytes > MAX_API_BODY_BYTES) {
-                rejected = true;
-                response.statusCode = HTTP_STATUS_PAYLOAD_TOO_LARGE;
-                // Remaining chunks are still drained (and discarded) by this
-                // same 'data' handler rather than buffered, bounding memory;
-                // the server's requestTimeout bounds how long that continues.
-                response.end(JSON.stringify({ error: 'Payload too large.' }));
-                return;
-              }
-              payload.push(chunk);
-            })
-            .on('end', async () => {
-              if (rejected) {
-                return;
-              }
-              switch (request.method) {
-                case 'GET':
-                  await this.handleGet(response);
-                  break;
-                case 'POST':
-                  await this.handlePost(payload, response);
-                  break;
-                default:
-                  this.platform.log.debug('No action matched.');
-                  response.statusCode = HTTP_STATUS_METHOD_NOT_ALLOWED;
-                  response.end();
-              }
-            });
-        })
-        .listen(apiServerPort, '0.0.0.0');
+        request
+          .on('data', (chunk: Buffer) => {
+            if (rejected) {
+              return;
+            }
+            receivedBytes += chunk.length;
+            if (receivedBytes > MAX_API_BODY_BYTES) {
+              rejected = true;
+              response.statusCode = HTTP_STATUS_PAYLOAD_TOO_LARGE;
+              // Remaining chunks are still drained (and discarded) by this
+              // same 'data' handler rather than buffered, bounding memory;
+              // the server's requestTimeout bounds how long that continues.
+              response.end(JSON.stringify({ error: 'Payload too large.' }));
+              return;
+            }
+            payload.push(chunk);
+          })
+          .on('end', async () => {
+            if (rejected) {
+              return;
+            }
+            switch (request.method) {
+              case 'GET':
+                await this.handleGet(response);
+                break;
+              case 'POST':
+                await this.handlePost(payload, response);
+                break;
+              default:
+                this.platform.log.debug('No action matched.');
+                response.statusCode = HTTP_STATUS_METHOD_NOT_ALLOWED;
+                response.end();
+            }
+          });
+      });
+      // Without this listener, an async server error (e.g. EADDRINUSE from a
+      // second Sync Box instance defaulting to the same port) is rethrown by
+      // Node as an uncaught exception, which Homebridge treats as fatal to
+      // the entire process rather than just this plugin.
+      this.server.on('error', e => {
+        this.platform.log.error('API server encountered an error.', e);
+      });
+      this.server.listen(apiServerPort, '0.0.0.0');
       this.server.requestTimeout = API_REQUEST_TIMEOUT_MS;
     } catch (e) {
       this.platform.log.error('API could not be started:', e);

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -116,12 +116,17 @@ export class ApiServer {
       this.server.on('error', e => {
         this.platform.log.error('API server encountered an error.', e);
       });
+      // listen() returns before the socket is actually bound, so logging
+      // success here (rather than from 'listening') would claim the server
+      // is up even when it fails to bind, e.g. EADDRINUSE.
+      this.server.on('listening', () => {
+        this.platform.log.info('API server started.');
+      });
       this.server.listen(apiServerPort, '0.0.0.0');
       this.server.requestTimeout = API_REQUEST_TIMEOUT_MS;
     } catch (e) {
       this.platform.log.error('API could not be started:', e);
     }
-    this.platform.log.info('API server started.');
   }
 
   private isAuthorized(

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -6,7 +6,11 @@ import * as https from 'node:https';
 import { Logger } from 'homebridge';
 import { HueSyncBoxPlatformConfig } from '../config.js';
 import AsyncLock, { AsyncLockOptions } from 'async-lock';
-import { HTTP_RETRY_COUNT, HTTP_RETRY_BASE_DELAY_MS } from './constants.js';
+import {
+  HTTP_RETRY_COUNT,
+  HTTP_RETRY_BASE_DELAY_MS,
+  MAX_SYNC_BOX_RESPONSE_BYTES,
+} from './constants.js';
 import { isValidState } from './validation.js';
 
 const fetch = fetch_retry(originalFetch, {
@@ -83,6 +87,10 @@ export class SyncBoxClient {
       method,
       body: body ? JSON.stringify(body) : null,
       agent: new https.Agent({ rejectUnauthorized: false, keepAlive: true }),
+      // Aborts the response stream once it exceeds this many bytes, so a
+      // spoofed oversized response can't be fully buffered by res.json()
+      // before isValidState() gets a chance to reject it.
+      size: MAX_SYNC_BOX_RESPONSE_BYTES,
     };
 
     this.log.debug(

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -7,6 +7,7 @@ import { Logger } from 'homebridge';
 import { HueSyncBoxPlatformConfig } from '../config.js';
 import AsyncLock, { AsyncLockOptions } from 'async-lock';
 import { HTTP_RETRY_COUNT, HTTP_RETRY_BASE_DELAY_MS } from './constants.js';
+import { isValidState } from './validation.js';
 
 const fetch = fetch_retry(originalFetch, {
   retries: HTTP_RETRY_COUNT,
@@ -100,6 +101,18 @@ export class SyncBoxClient {
       );
       throw new Error(`Error: ${res.status} - ${res.statusText}`);
     }
-    return method === 'GET' ? ((await res.json()) as T) : (null as T);
+    if (method !== 'GET') {
+      return null as T;
+    }
+    const json = await res.json();
+    // The Sync Box's cert is accepted without identity verification
+    // (rejectUnauthorized: false), so a LAN-adjacent attacker able to spoof
+    // its responses must not be able to hand every accessory's update() a
+    // shape it dereferences unconditionally - that already crashed the
+    // entire Homebridge process, not just this plugin's accessories.
+    if (!isValidState(json)) {
+      throw new Error('Sync Box returned a malformed state response.');
+    }
+    return json as T;
   }
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -69,3 +69,10 @@ export const MIN_API_TOKEN_LENGTH = 32;
 export const MAX_API_BODY_BYTES = 100_000;
 // No legitimate request to this API should take anywhere near this long.
 export const API_REQUEST_TIMEOUT_MS = 10_000;
+
+// ===== Sync Box Client Security Constants =====
+// The Sync Box's cert is accepted without identity verification, so a
+// LAN-adjacent attacker able to spoof its address could otherwise return an
+// unbounded body and exhaust the shared Homebridge process's heap before
+// isValidState() ever runs. Legitimate state responses are a few KB.
+export const MAX_SYNC_BOX_RESPONSE_BYTES = 100_000;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -42,6 +42,20 @@ function isValidHdmiInput(value: unknown): boolean {
   return isPlainObject(value) && isNonEmptyString(value.name);
 }
 
+// BaseTvDevice's remote up/down handlers do arithmetic on this value and
+// serialize it back to the Sync Box, and updateLightbulb() forwards it to
+// the HomeKit Brightness characteristic - a non-finite value turns into
+// `null`/NaN in both places instead of a TypeError, so it's a correctness
+// bound rather than a crash guard, but still worth rejecting up front.
+function isValidBrightness(value: unknown): boolean {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= BRIGHTNESS_MIN &&
+    value <= BRIGHTNESS_MAX_SYNCBOX
+  );
+}
+
 /**
  * TvDevice.createInputServices() unconditionally dereferences
  * hdmi.input1 through input4 (state.hdmi[`input${i}`].name) when the TV
@@ -75,10 +89,11 @@ function isValidHueState(value: unknown): boolean {
 
 /**
  * Confirms the shape every accessory unconditionally dereferences
- * (device.name/firmwareVersion/uniqueId, execution.mode/hdmiSource,
- * hue.groups[*].name, hdmi.input1-4.name) is actually present, so a
- * malformed or spoofed Sync Box response fails here instead of throwing a
- * TypeError deep inside an accessory's update().
+ * (device.name/firmwareVersion/uniqueId, execution.mode/hdmiSource/
+ * brightness, hue.groups[*].name, hdmi.input1-4.name) is actually present,
+ * so a malformed or spoofed Sync Box response fails here instead of
+ * throwing a TypeError - or forwarding NaN/empty values to HomeKit - deep
+ * inside an accessory's update().
  */
 export function isValidState(value: unknown): value is State {
   if (!isPlainObject(value)) {
@@ -93,6 +108,7 @@ export function isValidState(value: unknown): value is State {
     isPlainObject(execution) &&
     typeof execution.mode === 'string' &&
     typeof execution.hdmiSource === 'string' &&
+    isValidBrightness(execution.brightness) &&
     isValidHueState(hue) &&
     isValidHdmiState(hdmi)
   );

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -13,8 +13,7 @@ import {
 } from './constants.js';
 
 export type ValidationResult<T> =
-  | { ok: true; value: Partial<T> }
-  | { ok: false; error: string };
+  { ok: true; value: Partial<T> } | { ok: false; error: string };
 
 const VALID_EXECUTION_MODES: string[] = [
   MODE_VIDEO,
@@ -88,7 +87,7 @@ export function isValidState(value: unknown): value is State {
   const { device, execution, hue, hdmi } = value;
   return (
     isPlainObject(device) &&
-    typeof device.name === 'string' &&
+    isNonEmptyString(device.name) &&
     typeof device.firmwareVersion === 'string' &&
     typeof device.uniqueId === 'string' &&
     isPlainObject(execution) &&

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -108,6 +108,7 @@ export function isValidState(value: unknown): value is State {
     isPlainObject(execution) &&
     typeof execution.mode === 'string' &&
     typeof execution.hdmiSource === 'string' &&
+    HDMI_SOURCE_PATTERN.test(execution.hdmiSource) &&
     isValidBrightness(execution.brightness) &&
     isValidHueState(hue) &&
     isValidHdmiState(hdmi)

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -13,7 +13,8 @@ import {
 } from './constants.js';
 
 export type ValidationResult<T> =
-  { ok: true; value: Partial<T> } | { ok: false; error: string };
+  | { ok: true; value: Partial<T> }
+  | { ok: false; error: string };
 
 const VALID_EXECUTION_MODES: string[] = [
   MODE_VIDEO,
@@ -30,6 +31,29 @@ export function isPlainObject(
   value: unknown
 ): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Confirms the shape every accessory unconditionally dereferences
+ * (device.name/firmwareVersion/uniqueId, execution.mode, hue, hdmi) is
+ * actually present, so a malformed or spoofed Sync Box response fails here
+ * instead of throwing a TypeError deep inside an accessory's update().
+ */
+export function isValidState(value: unknown): value is State {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  const { device, execution, hue, hdmi } = value;
+  return (
+    isPlainObject(device) &&
+    typeof device.name === 'string' &&
+    typeof device.firmwareVersion === 'string' &&
+    typeof device.uniqueId === 'string' &&
+    isPlainObject(execution) &&
+    typeof execution.mode === 'string' &&
+    isPlainObject(hue) &&
+    isPlainObject(hdmi)
+  );
 }
 
 function validateIntensityPayload(

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -33,8 +33,14 @@ export function isPlainObject(
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+// Matches BaseTvDevice.getInputService()'s `if (!name) throw` guard, so a
+// blank name fails validation instead of throwing during accessory setup.
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
 function isValidHdmiInput(value: unknown): boolean {
-  return isPlainObject(value) && typeof value.name === 'string';
+  return isPlainObject(value) && isNonEmptyString(value.name);
 }
 
 /**
@@ -64,7 +70,7 @@ function isValidHueState(value: unknown): boolean {
     return false;
   }
   return Object.values(value.groups).every(
-    group => isPlainObject(group) && typeof group.name === 'string'
+    group => isPlainObject(group) && isNonEmptyString(group.name)
   );
 }
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -33,11 +33,47 @@ export function isPlainObject(
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function isValidHdmiInput(value: unknown): boolean {
+  return isPlainObject(value) && typeof value.name === 'string';
+}
+
+/**
+ * TvDevice.createInputServices() unconditionally dereferences
+ * hdmi.input1 through input4 (state.hdmi[`input${i}`].name) when the TV
+ * accessory is enabled, so every input slot must be present with a name.
+ */
+function isValidHdmiState(value: unknown): boolean {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  for (let i = HDMI_INPUT_MIN; i <= HDMI_INPUT_MAX; i++) {
+    if (!isValidHdmiInput(value[`input${i}`])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * EntertainmentTvDevice.createInputServices()/updateTv() unconditionally
+ * dereference each entry in hue.groups (group.name) when the entertainment
+ * TV accessory is enabled, so every group must be an object with a name.
+ */
+function isValidHueState(value: unknown): boolean {
+  if (!isPlainObject(value) || !isPlainObject(value.groups)) {
+    return false;
+  }
+  return Object.values(value.groups).every(
+    group => isPlainObject(group) && typeof group.name === 'string'
+  );
+}
+
 /**
  * Confirms the shape every accessory unconditionally dereferences
- * (device.name/firmwareVersion/uniqueId, execution.mode, hue, hdmi) is
- * actually present, so a malformed or spoofed Sync Box response fails here
- * instead of throwing a TypeError deep inside an accessory's update().
+ * (device.name/firmwareVersion/uniqueId, execution.mode/hdmiSource,
+ * hue.groups[*].name, hdmi.input1-4.name) is actually present, so a
+ * malformed or spoofed Sync Box response fails here instead of throwing a
+ * TypeError deep inside an accessory's update().
  */
 export function isValidState(value: unknown): value is State {
   if (!isPlainObject(value)) {
@@ -51,8 +87,9 @@ export function isValidState(value: unknown): value is State {
     typeof device.uniqueId === 'string' &&
     isPlainObject(execution) &&
     typeof execution.mode === 'string' &&
-    isPlainObject(hue) &&
-    isPlainObject(hdmi)
+    typeof execution.hdmiSource === 'string' &&
+    isValidHueState(hue) &&
+    isValidHdmiState(hdmi)
   );
 }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -91,7 +91,15 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
 
     this.api.on('didFinishLaunching', async () => {
       this.log.debug('Executed didFinishLaunching callback');
-      await this.discoverDevices();
+      // A rejection here would otherwise escape this async event listener as
+      // an unhandled rejection, which Homebridge treats as fatal to the
+      // entire process rather than just this plugin - the exact failure mode
+      // this class of fix is meant to close off.
+      try {
+        await this.discoverDevices();
+      } catch (e) {
+        this.log.error('Failed to discover devices on startup.', e);
+      }
     });
 
     if (this.config.apiServerEnabled) {

--- a/test/unit/api-server.test.ts
+++ b/test/unit/api-server.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { ApiServer } from '../../src/api-server.js';
+import type { HueSyncBoxPlatform } from '../../src/platform.js';
+
+const VALID_TOKEN = 'a'.repeat(32);
+
+function makePlatform(config: Record<string, unknown>): HueSyncBoxPlatform {
+  return {
+    config,
+    log: {
+      error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+    },
+    client: { getState: jest.fn() },
+  } as unknown as HueSyncBoxPlatform;
+}
+
+function getServer(apiServer: ApiServer) {
+  return (apiServer as unknown as { server?: { close: () => void } }).server;
+}
+
+describe('ApiServer.start', () => {
+  it('refuses to start and logs an error when apiServerToken is not a string', () => {
+    const platform = makePlatform({
+      apiServerPort: 40299,
+      apiServerToken: 12345,
+    });
+    const apiServer = new ApiServer(platform);
+
+    apiServer.start();
+
+    expect(platform.log.error).toHaveBeenCalledWith(
+      expect.stringContaining('must be a string')
+    );
+    expect(getServer(apiServer)).toBeUndefined();
+  });
+
+  it('refuses to start and logs an error when apiServerToken is too short', () => {
+    const platform = makePlatform({
+      apiServerPort: 40299,
+      apiServerToken: 'short',
+    });
+    const apiServer = new ApiServer(platform);
+
+    apiServer.start();
+
+    expect(platform.log.error).toHaveBeenCalledWith(
+      expect.stringContaining('must be a string')
+    );
+    expect(getServer(apiServer)).toBeUndefined();
+  });
+
+  it('does not crash the process when two instances share a port (EADDRINUSE)', async () => {
+    const port = 40298;
+    const platformA = makePlatform({
+      apiServerPort: port,
+      apiServerToken: VALID_TOKEN,
+    });
+    const platformB = makePlatform({
+      apiServerPort: port,
+      apiServerToken: VALID_TOKEN,
+    });
+    const serverA = new ApiServer(platformA);
+    const serverB = new ApiServer(platformB);
+
+    try {
+      serverA.start();
+      // Give the OS time to actually bind the first server before the
+      // second attempts the same port; only then is EADDRINUSE guaranteed.
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      serverB.start();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // Prior to the fix, this EADDRINUSE was rethrown by Node as an
+      // uncaught exception instead of being logged - this test would crash
+      // the whole test process rather than fail an assertion.
+      expect(platformB.log.error).toHaveBeenCalledWith(
+        expect.stringContaining('API server encountered an error'),
+        expect.anything()
+      );
+    } finally {
+      getServer(serverA)?.close();
+      getServer(serverB)?.close();
+    }
+  }, 10000);
+});

--- a/test/unit/lib/validation.test.ts
+++ b/test/unit/lib/validation.test.ts
@@ -41,7 +41,7 @@ function makeFullState(): State {
       firmwareVersion: '1.0.0',
       uniqueId: 'unique-id',
     },
-    execution: { mode: 'video', hdmiSource: 'input1' },
+    execution: { mode: 'video', hdmiSource: 'input1', brightness: 150 },
     hue: makeState({ 'group-1': { name: 'Living Room' } }).hue,
     hdmi: makeHdmi(),
   } as State;
@@ -96,6 +96,29 @@ describe('isValidState', () => {
 
   it('rejects a response missing execution.hdmiSource', () => {
     const state = { ...makeFullState(), execution: { mode: 'video' } };
+    expect(isValidState(state)).toBe(false);
+  });
+
+  it('rejects a response missing or non-finite execution.brightness', () => {
+    expect(
+      isValidState({
+        ...makeFullState(),
+        execution: omit(makeFullState().execution, 'brightness'),
+      })
+    ).toBe(false);
+    expect(
+      isValidState({
+        ...makeFullState(),
+        execution: { ...makeFullState().execution, brightness: NaN },
+      })
+    ).toBe(false);
+  });
+
+  it('rejects a response with out-of-range execution.brightness', () => {
+    const state = {
+      ...makeFullState(),
+      execution: { ...makeFullState().execution, brightness: 201 },
+    };
     expect(isValidState(state)).toBe(false);
   });
 

--- a/test/unit/lib/validation.test.ts
+++ b/test/unit/lib/validation.test.ts
@@ -28,6 +28,12 @@ function makeHdmi(): State['hdmi'] {
   } as State['hdmi'];
 }
 
+function omit<T extends object, K extends keyof T>(obj: T, key: K): Omit<T, K> {
+  const clone: Partial<T> = { ...obj };
+  delete clone[key];
+  return clone as Omit<T, K>;
+}
+
 function makeFullState(): State {
   return {
     device: {
@@ -62,8 +68,7 @@ describe('isValidState', () => {
   });
 
   it('rejects a response missing execution entirely', () => {
-    const { execution: _execution, ...rest } = makeFullState();
-    expect(isValidState(rest)).toBe(false);
+    expect(isValidState(omit(makeFullState(), 'execution'))).toBe(false);
   });
 
   it('rejects a response where execution.mode is not a string', () => {
@@ -76,11 +81,17 @@ describe('isValidState', () => {
     expect(isValidState(state)).toBe(false);
   });
 
+  it('rejects a response where device.name is empty', () => {
+    const state = {
+      ...makeFullState(),
+      device: { ...makeFullState().device, name: '' },
+    };
+    expect(isValidState(state)).toBe(false);
+  });
+
   it('rejects a response missing hue or hdmi', () => {
-    const { hue: _hue, ...withoutHue } = makeFullState();
-    expect(isValidState(withoutHue)).toBe(false);
-    const { hdmi: _hdmi, ...withoutHdmi } = makeFullState();
-    expect(isValidState(withoutHdmi)).toBe(false);
+    expect(isValidState(omit(makeFullState(), 'hue'))).toBe(false);
+    expect(isValidState(omit(makeFullState(), 'hdmi'))).toBe(false);
   });
 
   it('rejects a response missing execution.hdmiSource', () => {
@@ -89,8 +100,10 @@ describe('isValidState', () => {
   });
 
   it('rejects a response missing an HDMI input slot', () => {
-    const { input4: _input4, ...hdmi } = makeFullState().hdmi;
-    const state = { ...makeFullState(), hdmi };
+    const state = {
+      ...makeFullState(),
+      hdmi: omit(makeHdmi(), 'input4'),
+    };
     expect(isValidState(state)).toBe(false);
   });
 

--- a/test/unit/lib/validation.test.ts
+++ b/test/unit/lib/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import {
   isPlainObject,
+  isValidState,
   validateExecution,
   validateHue,
 } from '../../../src/lib/validation.js';
@@ -18,6 +19,19 @@ function makeState(groups: Record<string, { name: string }>): State {
   } as State;
 }
 
+function makeFullState(): State {
+  return {
+    device: {
+      name: 'Sync Box',
+      firmwareVersion: '1.0.0',
+      uniqueId: 'unique-id',
+    },
+    execution: { mode: 'video' },
+    hue: makeState({}).hue,
+    hdmi: {},
+  } as State;
+}
+
 describe('isPlainObject', () => {
   it('accepts plain objects', () => {
     expect(isPlainObject({})).toBe(true);
@@ -30,6 +44,41 @@ describe('isPlainObject', () => {
     expect(isPlainObject('a string')).toBe(false);
     expect(isPlainObject(42)).toBe(false);
     expect(isPlainObject(undefined)).toBe(false);
+  });
+});
+
+describe('isValidState', () => {
+  it('accepts a well-formed state', () => {
+    expect(isValidState(makeFullState())).toBe(true);
+  });
+
+  it('rejects a response missing execution entirely', () => {
+    const { execution: _execution, ...rest } = makeFullState();
+    expect(isValidState(rest)).toBe(false);
+  });
+
+  it('rejects a response where execution.mode is not a string', () => {
+    const state = { ...makeFullState(), execution: { mode: 42 } };
+    expect(isValidState(state)).toBe(false);
+  });
+
+  it('rejects a response missing device fields', () => {
+    const state = { ...makeFullState(), device: { name: 'Sync Box' } };
+    expect(isValidState(state)).toBe(false);
+  });
+
+  it('rejects a response missing hue or hdmi', () => {
+    const { hue: _hue, ...withoutHue } = makeFullState();
+    expect(isValidState(withoutHue)).toBe(false);
+    const { hdmi: _hdmi, ...withoutHdmi } = makeFullState();
+    expect(isValidState(withoutHdmi)).toBe(false);
+  });
+
+  it('rejects non-object and null responses', () => {
+    expect(isValidState(null)).toBe(false);
+    expect(isValidState(undefined)).toBe(false);
+    expect(isValidState('not an object')).toBe(false);
+    expect(isValidState([])).toBe(false);
   });
 });
 

--- a/test/unit/lib/validation.test.ts
+++ b/test/unit/lib/validation.test.ts
@@ -102,6 +102,22 @@ describe('isValidState', () => {
     expect(isValidState(state)).toBe(false);
   });
 
+  it('rejects a response where an HDMI input name is empty', () => {
+    const state = {
+      ...makeFullState(),
+      hdmi: { ...makeHdmi(), input1: { name: '' } },
+    };
+    expect(isValidState(state)).toBe(false);
+  });
+
+  it('rejects a response where a hue group name is empty', () => {
+    const state = {
+      ...makeFullState(),
+      hue: makeState({ 'group-1': { name: '' } }).hue,
+    };
+    expect(isValidState(state)).toBe(false);
+  });
+
   it('accepts a response with no entertainment groups', () => {
     const state = { ...makeFullState(), hue: makeState({}).hue };
     expect(isValidState(state)).toBe(true);

--- a/test/unit/lib/validation.test.ts
+++ b/test/unit/lib/validation.test.ts
@@ -99,6 +99,14 @@ describe('isValidState', () => {
     expect(isValidState(state)).toBe(false);
   });
 
+  it('rejects a response where execution.hdmiSource is not a valid input', () => {
+    const state = {
+      ...makeFullState(),
+      execution: { ...makeFullState().execution, hdmiSource: 'invalid' },
+    };
+    expect(isValidState(state)).toBe(false);
+  });
+
   it('rejects a response missing or non-finite execution.brightness', () => {
     expect(
       isValidState({

--- a/test/unit/lib/validation.test.ts
+++ b/test/unit/lib/validation.test.ts
@@ -19,6 +19,15 @@ function makeState(groups: Record<string, { name: string }>): State {
   } as State;
 }
 
+function makeHdmi(): State['hdmi'] {
+  return {
+    input1: { name: 'Input 1' },
+    input2: { name: 'Input 2' },
+    input3: { name: 'Input 3' },
+    input4: { name: 'Input 4' },
+  } as State['hdmi'];
+}
+
 function makeFullState(): State {
   return {
     device: {
@@ -26,9 +35,9 @@ function makeFullState(): State {
       firmwareVersion: '1.0.0',
       uniqueId: 'unique-id',
     },
-    execution: { mode: 'video' },
-    hue: makeState({}).hue,
-    hdmi: {},
+    execution: { mode: 'video', hdmiSource: 'input1' },
+    hue: makeState({ 'group-1': { name: 'Living Room' } }).hue,
+    hdmi: makeHdmi(),
   } as State;
 }
 
@@ -72,6 +81,46 @@ describe('isValidState', () => {
     expect(isValidState(withoutHue)).toBe(false);
     const { hdmi: _hdmi, ...withoutHdmi } = makeFullState();
     expect(isValidState(withoutHdmi)).toBe(false);
+  });
+
+  it('rejects a response missing execution.hdmiSource', () => {
+    const state = { ...makeFullState(), execution: { mode: 'video' } };
+    expect(isValidState(state)).toBe(false);
+  });
+
+  it('rejects a response missing an HDMI input slot', () => {
+    const { input4: _input4, ...hdmi } = makeFullState().hdmi;
+    const state = { ...makeFullState(), hdmi };
+    expect(isValidState(state)).toBe(false);
+  });
+
+  it('rejects a response where an HDMI input is missing a name', () => {
+    const state = {
+      ...makeFullState(),
+      hdmi: { ...makeHdmi(), input1: {} },
+    };
+    expect(isValidState(state)).toBe(false);
+  });
+
+  it('accepts a response with no entertainment groups', () => {
+    const state = { ...makeFullState(), hue: makeState({}).hue };
+    expect(isValidState(state)).toBe(true);
+  });
+
+  it('rejects a response where a hue group is missing a name', () => {
+    const state = {
+      ...makeFullState(),
+      hue: makeState({ 'group-1': {} as { name: string } }).hue,
+    };
+    expect(isValidState(state)).toBe(false);
+  });
+
+  it('rejects a response where hue.groups is not an object', () => {
+    const state = {
+      ...makeFullState(),
+      hue: { ...makeFullState().hue, groups: 'not-an-object' },
+    };
+    expect(isValidState(state)).toBe(false);
   });
 
   it('rejects non-object and null responses', () => {


### PR DESCRIPTION
## Summary

Fixes the three MEDIUM findings from a `/security-audit` run against `main` @ 735f4bc (which had just merged #429's DoS/secret-leak/validation fixes). All three are variants of the same underlying issue: this plugin runs in Homebridge's default (non-isolated) process, so *any* uncaught exception anywhere in its code kills the entire bridge — every plugin's accessories, not just this one's.

- **`src/api-server.ts`**: `start()`'s guard against a bad `apiServerToken` silently passed a non-string value (e.g. a bare JSON number from a malformed config), which then threw inside `Buffer.from()` on the first authenticated request. Fixed by checking `typeof apiServerToken !== 'string'` before the length check.
- **`src/api-server.ts`**: the `http.Server` had no `'error'` listener, so `EADDRINUSE` from two Sync Box instances defaulting to the same port (a scenario this plugin explicitly supports via `uuidSeed`) was rethrown by Node as an uncaught exception, crash-looping the process. Fixed by attaching `.on('error', ...)` before `.listen()`.
- **`src/lib/client.ts`**: the Sync Box's GET response was parsed with a bare `as T` type assertion — no runtime shape check. Since the client already accepts the device's self-signed cert with no other identity verification, a LAN-adjacent attacker able to spoof `config.syncBoxIpAddress` could supply a response missing `execution`, which threw a `TypeError` deep inside every accessory's `update()`. Fixed by adding `isValidState()` in `src/lib/validation.ts` and rejecting malformed responses in `sendRequest()`, which flows into the existing `getState()` error handling (already returns `null`, already handled safely by every caller).

A fourth candidate (stale entertainment-area labels after Hue group recycling) was investigated and downgraded to a functional/UX bug during the audit's validation phase — it requires no attacker and crosses no security boundary, so it isn't included here.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run prettier`
- [x] `npm run build`
- [x] `npm test` (64/64 passing, including new regression tests for all three fixes: non-string token rejection, EADDRINUSE no longer crashes, and `isValidState` shape validation)

https://claude.ai/code/session_01XFTyCpHzsC78AriZU2F1T5