### PR TITLE
fix(client): bound Sync Box requests and stop polling overlap

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -27,8 +27,12 @@ const fetch = fetch_retry(originalFetch, {
   // full backoff delay on attempts that fail instantly for no benefit.
   // Real network errors (connection refused/reset, DNS failure, etc.) still
   // get retried normally.
+  //
+  // fetch-retry only enforces its own `retries` option when `retryOn` is an
+  // array; a function `retryOn` fully replaces that bound, so this has to
+  // check `attempt` itself or a persistent network error retries forever.
   retryOn: (attempt: number, error: Error | null) => {
-    return !!error && error.name !== 'AbortError';
+    return !!error && error.name !== 'AbortError' && attempt < HTTP_RETRY_COUNT;
   },
 });
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -10,6 +10,9 @@ import {
   HTTP_RETRY_COUNT,
   HTTP_RETRY_BASE_DELAY_MS,
   MAX_SYNC_BOX_RESPONSE_BYTES,
+  SYNC_BOX_REQUEST_TIMEOUT_MS,
+  SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS,
+  SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS,
 } from './constants.js';
 import { isValidState } from './validation.js';
 
@@ -18,16 +21,29 @@ const fetch = fetch_retry(originalFetch, {
   retryDelay: attempt => {
     return Math.pow(2, attempt) * HTTP_RETRY_BASE_DELAY_MS; // 1000, 2000, 4000
   },
+  // fetch-retry reuses the same request `init` - and so the same
+  // AbortSignal - across every retry attempt. Once our own request timeout
+  // fires, the signal is permanently aborted, so retrying just burns the
+  // full backoff delay on attempts that fail instantly for no benefit.
+  // Real network errors (connection refused/reset, DNS failure, etc.) still
+  // get retried normally.
+  retryOn: (attempt: number, error: Error | null) => {
+    return !!error && error.name !== 'AbortError';
+  },
 });
 
 export class SyncBoxClient {
   private readonly LOCK_KEY = 'sync-box';
   private readonly LOCK_OPTIONS: AsyncLockOptions = {
-    timeout: 10000,
-    maxExecutionTime: 15000,
+    timeout: SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS,
+    maxExecutionTime: SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS,
   };
 
   private readonly lock: AsyncLock;
+  private readonly agent = new https.Agent({
+    rejectUnauthorized: false,
+    keepAlive: true,
+  });
 
   constructor(
     private readonly log: Logger | Console,
@@ -44,7 +60,7 @@ export class SyncBoxClient {
         this.LOCK_OPTIONS
       )
       .catch(e => {
-        this.log.error('Sync box is offline', e);
+        this.log.error('Failed to get state from Sync Box:', e);
         return null;
       });
   }
@@ -86,11 +102,15 @@ export class SyncBoxClient {
       },
       method,
       body: body ? JSON.stringify(body) : null,
-      agent: new https.Agent({ rejectUnauthorized: false, keepAlive: true }),
+      agent: this.agent,
       // Aborts the response stream once it exceeds this many bytes, so a
       // spoofed oversized response can't be fully buffered by res.json()
       // before isValidState() gets a chance to reject it.
       size: MAX_SYNC_BOX_RESPONSE_BYTES,
+      // Bounds the whole request (all retries included - see the retryOn
+      // override above) in case the Sync Box accepts the connection but
+      // never sends a response; node-fetch applies no timeout on its own.
+      signal: AbortSignal.timeout(SYNC_BOX_REQUEST_TIMEOUT_MS),
     };
 
     this.log.debug(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -52,6 +52,22 @@ export const HTTP_STATUS_BAD_REQUEST = 400;
 export const HTTP_STATUS_PAYLOAD_TOO_LARGE = 413;
 export const HTTP_STATUS_METHOD_NOT_ALLOWED = 405;
 export const HTTP_STATUS_INTERNAL_ERROR = 500;
+// Aborts a single Sync Box request (all retries included, since fetch-retry
+// reuses the same AbortSignal) if it hangs with no response. Without this,
+// a connected-but-silent socket hangs node-fetch forever - no timeout of any
+// kind is applied by node-fetch v3 or fetch-retry on their own.
+export const SYNC_BOX_REQUEST_TIMEOUT_MS = 8000;
+// Queue-wait timeout for async-lock: how long a caller waits for a turn.
+export const SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS = 10000;
+// Worst case one sendRequest() call can take: SYNC_BOX_REQUEST_TIMEOUT_MS
+// for the first attempt, plus up to HTTP_RETRY_COUNT retries of real
+// (non-abort) network errors backing off at HTTP_RETRY_BASE_DELAY_MS *
+// 2^attempt each. Must stay comfortably above that worst case - if a job
+// legitimately runs longer than this, async-lock hands its slot to the next
+// queued caller while the original request keeps running in the background,
+// which can let two requests execute concurrently against the lock's
+// mutual-exclusion guarantee.
+export const SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS = 20000;
 
 // ===== Intensity Constants =====
 export const VALID_INTENSITIES: string[] = [

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -229,6 +229,10 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
     this.log.debug(`Discovered ${this.devices.length} devices`);
 
     await this.update(state);
+    this.schedulePolling();
+  }
+
+  private schedulePolling(): void {
     let polling = false;
     setInterval(async () => {
       // setInterval doesn't wait for a previous tick's promise to settle.

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -229,9 +229,24 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
     this.log.debug(`Discovered ${this.devices.length} devices`);
 
     await this.update(state);
+    let polling = false;
     setInterval(async () => {
-      const state = await this.client.getState();
-      await this.update(state);
+      // setInterval doesn't wait for a previous tick's promise to settle.
+      // If one getState() call runs long (retries, a slow response), firing
+      // another on top of it just queues up behind the same client-side
+      // lock instead of skipping the tick, and the queue can grow without
+      // bound on a short poll interval. Skip overlapping ticks instead.
+      if (polling) {
+        this.log.debug('Skipping poll tick, previous update still in progress');
+        return;
+      }
+      polling = true;
+      try {
+        const state = await this.client.getState();
+        await this.update(state);
+      } finally {
+        polling = false;
+      }
     }, this.config.updateIntervalInSeconds * 1000);
   }
 

--- a/test/unit/lib/client.test.ts
+++ b/test/unit/lib/client.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { HueSyncBoxPlatformConfig } from '../../../src/config.js';
+import type { State } from '../../../src/state.js';
+
+const mockFetch = jest.fn();
+
+// SyncBoxClient imports node-fetch as its default export and wraps it with
+// fetch-retry at module load time, so the mock has to be installed before
+// src/lib/client.js (and transitively node-fetch) is ever imported.
+jest.unstable_mockModule('node-fetch', () => ({
+  default: mockFetch,
+}));
+
+const { SyncBoxClient } = await import('../../../src/lib/client.js');
+const { HTTP_RETRY_BASE_DELAY_MS, MAX_SYNC_BOX_RESPONSE_BYTES } =
+  await import('../../../src/lib/constants.js');
+
+function makeLog() {
+  return {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+function makeConfig(): HueSyncBoxPlatformConfig {
+  return {
+    syncBoxIpAddress: '10.0.0.5',
+    syncBoxApiAccessToken: 'test-token',
+  } as HueSyncBoxPlatformConfig;
+}
+
+function makeValidState(): State {
+  return {
+    device: {
+      name: 'Sync Box',
+      firmwareVersion: '1.0.0',
+      uniqueId: 'abc123',
+    },
+    execution: {
+      mode: 'video',
+      hdmiSource: 'input1',
+      brightness: 100,
+    },
+    hue: {
+      groups: {},
+    },
+    hdmi: {
+      input1: { name: 'Input 1' },
+      input2: { name: 'Input 2' },
+      input3: { name: 'Input 3' },
+      input4: { name: 'Input 4' },
+    },
+  } as unknown as State;
+}
+
+function okResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+  };
+}
+
+function errorResponse(status: number, statusText: string, body: unknown) {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: async () => body,
+  };
+}
+
+describe('SyncBoxClient', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('bounds each request with an AbortSignal and reuses a single https.Agent across calls', async () => {
+    mockFetch.mockResolvedValue(okResponse(makeValidState()));
+    const client = new SyncBoxClient(makeLog(), makeConfig());
+
+    await client.getState();
+    await client.getState();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const [, firstOptions] = mockFetch.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    const [, secondOptions] = mockFetch.mock.calls[1] as [
+      string,
+      Record<string, unknown>,
+    ];
+
+    expect(firstOptions.signal).toBeInstanceOf(AbortSignal);
+    expect(firstOptions.size).toBe(MAX_SYNC_BOX_RESPONSE_BYTES);
+    expect(firstOptions.agent).toBeDefined();
+    // A fresh https.Agent per request was the original bug - the fix reuses
+    // one instance across the client's lifetime.
+    expect(secondOptions.agent).toBe(firstOptions.agent);
+    expect(secondOptions.signal).not.toBe(firstOptions.signal);
+  });
+
+  it('does not retry once its own request timeout aborts the request', async () => {
+    const abortError = new Error('The operation was aborted.');
+    abortError.name = 'AbortError';
+    mockFetch.mockRejectedValue(abortError);
+    const log = makeLog();
+    const client = new SyncBoxClient(log, makeConfig());
+
+    const result = await client.getState();
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(log.error).toHaveBeenCalledWith(
+      'Failed to get state from Sync Box:',
+      abortError
+    );
+  });
+
+  it('retries a real network error and succeeds once the retry resolves', async () => {
+    jest.useFakeTimers();
+    try {
+      const validState = makeValidState();
+      mockFetch
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce(okResponse(validState));
+      const log = makeLog();
+      const client = new SyncBoxClient(log, makeConfig());
+
+      const resultPromise = client.getState();
+      // fetch-retry's first backoff delay is 2^0 * HTTP_RETRY_BASE_DELAY_MS.
+      await jest.advanceTimersByTimeAsync(HTTP_RETRY_BASE_DELAY_MS);
+      const result = await resultPromise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).not.toBeNull();
+      expect(log.error).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('bounds retries to HTTP_RETRY_COUNT even for a persistent network error', async () => {
+    jest.useFakeTimers();
+    try {
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+      const log = makeLog();
+      const client = new SyncBoxClient(log, makeConfig());
+
+      const resultPromise = client.getState();
+      // Cumulative backoff for HTTP_RETRY_COUNT retries: 1000+2000+4000=7000ms.
+      await jest.advanceTimersByTimeAsync(7000);
+      const result = await resultPromise;
+
+      expect(result).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    } finally {
+      jest.useRealTimers();
+    }
+  }, 3000);
+
+  it('does not retry an HTTP error status and logs then returns null', async () => {
+    mockFetch.mockResolvedValue(
+      errorResponse(500, 'Internal Server Error', { error: 'boom' })
+    );
+    const log = makeLog();
+    const client = new SyncBoxClient(log, makeConfig());
+
+    const result = await client.getState();
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(log.error).toHaveBeenCalledWith(
+      'Failed to get state from Sync Box:',
+      expect.any(Error)
+    );
+  });
+
+  it('rejects a malformed state response instead of forwarding it', async () => {
+    mockFetch.mockResolvedValue(okResponse({ not: 'a valid state' }));
+    const log = makeLog();
+    const client = new SyncBoxClient(log, makeConfig());
+
+    const result = await client.getState();
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(log.error).toHaveBeenCalledWith(
+      'Failed to get state from Sync Box:',
+      expect.objectContaining({
+        message: 'Sync Box returned a malformed state response.',
+      })
+    );
+  });
+
+  it('returns the parsed state on success', async () => {
+    const validState = makeValidState();
+    mockFetch.mockResolvedValue(okResponse(validState));
+    const client = new SyncBoxClient(makeLog(), makeConfig());
+
+    const result = await client.getState();
+
+    expect(result).toEqual(validState);
+  });
+});

--- a/test/unit/lib/constants.test.ts
+++ b/test/unit/lib/constants.test.ts
@@ -25,6 +25,8 @@ import {
   HTTP_RETRY_BASE_DELAY_MS,
   HTTP_STATUS_OK,
   HTTP_STATUS_UNAUTHORIZED,
+  SYNC_BOX_REQUEST_TIMEOUT_MS,
+  SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS,
 } from '../../../src/lib/constants.js';
 
 describe('Constants', () => {
@@ -125,6 +127,26 @@ describe('Constants', () => {
     it('should have positive retry values', () => {
       expect(HTTP_RETRY_COUNT).toBeGreaterThan(0);
       expect(HTTP_RETRY_BASE_DELAY_MS).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Sync Box Client Timing Constants', () => {
+    it('should keep the lock max execution time comfortably above the worst-case request time', () => {
+      // Mirrors sendRequest()'s actual worst case: the bounded first
+      // attempt, plus every retry backing off at HTTP_RETRY_BASE_DELAY_MS *
+      // 2^attempt. If this ever regresses, async-lock can hand a request's
+      // slot to the next queued caller while the original is still running,
+      // letting two requests execute concurrently.
+      let worstCaseRetryDelay = 0;
+      for (let attempt = 0; attempt < HTTP_RETRY_COUNT; attempt++) {
+        worstCaseRetryDelay += Math.pow(2, attempt) * HTTP_RETRY_BASE_DELAY_MS;
+      }
+      const worstCaseRequestTime =
+        SYNC_BOX_REQUEST_TIMEOUT_MS + worstCaseRetryDelay;
+
+      expect(SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS).toBeGreaterThan(
+        worstCaseRequestTime
+      );
     });
   });
 });

--- a/test/unit/platform.test.ts
+++ b/test/unit/platform.test.ts
@@ -1,0 +1,96 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import { HueSyncBoxPlatform } from '../../src/platform.js';
+import type { API, Logging, PlatformConfig } from 'homebridge';
+
+function makeApi(): API {
+  return {
+    hap: {
+      Categories: {
+        TV_SET_TOP_BOX: 1,
+        TV_STREAMING_STICK: 2,
+        AUDIO_RECEIVER: 3,
+        TELEVISION: 4,
+      },
+      uuid: { generate: jest.fn(() => 'uuid') },
+    },
+    on: jest.fn(),
+  } as unknown as API;
+}
+
+function makeLog(): Logging {
+  return {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as Logging;
+}
+
+function makeConfig(): PlatformConfig {
+  return {
+    platform: 'HueSyncBox',
+    name: 'Test',
+    syncBoxIpAddress: '10.0.0.5',
+    syncBoxApiAccessToken: 'test-token',
+    apiServerEnabled: false,
+    updateIntervalInSeconds: 1,
+  } as PlatformConfig;
+}
+
+type PollingPlatform = HueSyncBoxPlatform & { schedulePolling(): void };
+
+describe('HueSyncBoxPlatform polling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('skips a poll tick while the previous one is still in flight', async () => {
+    const platform = new HueSyncBoxPlatform(makeLog(), makeConfig(), makeApi());
+    let resolveFirst: (value: null) => void = () => {
+      throw new Error('resolveFirst called before assignment');
+    };
+    const getState = jest
+      .spyOn(platform.client, 'getState')
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockResolvedValue(null);
+    const update = jest.spyOn(platform, 'update').mockResolvedValue(undefined);
+
+    (platform as PollingPlatform).schedulePolling();
+
+    // Tick 1: starts a getState() call that never resolves on its own.
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(getState).toHaveBeenCalledTimes(1);
+
+    // Tick 2: fires while tick 1 is still pending - must be skipped, not queued.
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(getState).toHaveBeenCalledTimes(1);
+    expect(platform.log.debug).toHaveBeenCalledWith(
+      'Skipping poll tick, previous update still in progress'
+    );
+
+    // Let tick 1 finish, then confirm polling resumes on the next tick.
+    resolveFirst(null);
+    await jest.advanceTimersByTimeAsync(0);
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(getState).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- `sendRequest()` had no request-level timeout - node-fetch v3 applies none by default, so a connected-but-silent socket hung forever. async-lock's `maxExecutionTime` only abandoned the *lock's* promise when it fired, it did not cancel the underlying request, so the hung fetch (and its socket) kept running in the background indefinitely.
- `platform.ts`'s `setInterval` poll loop fired every tick regardless of whether the previous `getState()` call had finished, so a single slow/stuck request combined with a short poll interval piled up queued lock acquisitions that all timed out in a burst.
- Both surfaced identically as `"Sync box is offline"`, which is misleading when the device is actually reachable (confirmed via `telnet` in the report) and the real problem is client-side.

## Changes

- `sendRequest()` now bounds the whole operation (all retries included, since `fetch-retry` reuses the same `init`/signal across attempts) with `AbortSignal.timeout()`.
- Added a `retryOn` override so `fetch-retry` doesn't retry our own deliberate timeout (`AbortError`) - retrying against an already-aborted signal just burns the full backoff delay for an instant failure. Real network errors still retry as before.
- Reused a single `https.Agent` instance instead of constructing a new one per request.
- `platform.ts` now skips a poll tick if the previous one is still in flight instead of letting `setInterval` queue another call behind the lock. The poll-guard logic is extracted into a `schedulePolling()` method so it's unit-testable in isolation.
- Retuned async-lock's `maxExecutionTime` to comfortably exceed the new bounded worst-case request time, and reworded the "offline" log message.

**Follow-up fix caught by the new tests:** `fetch-retry` only enforces its own `retries` count when `retryOn` is an array - passing a function for `retryOn` (needed to exclude our own `AbortError` from retries) silently bypassed `HTTP_RETRY_COUNT` entirely, so a persistent real network error would have retried forever instead of stopping after 3 attempts. `retryOn` now checks the attempt count itself.

Fixes #431

## Tests

Added `test/unit/lib/client.test.ts`, `test/unit/platform.test.ts`, and an invariant check in `test/unit/lib/constants.test.ts`:

- Each request is bounded by an `AbortSignal`, and the `https.Agent` is reused across calls.
- Our own timeout (`AbortError`) is never retried.
- A real network error is retried and can still succeed.
- A persistent real network error is bounded to `HTTP_RETRY_COUNT` retries (this is the case that caught the bug above).
- Non-ok HTTP responses and malformed/spoofed state responses are not retried and return `null`.
- `schedulePolling()` skips a tick while the previous one is still in flight, and resumes once it finishes.
- `SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS` stays comfortably above the worst-case bounded request time.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (85 tests, all pass)
- [x] `npm run build`
- [ ] Reporter to confirm the misleading "offline" bursts stop under their config (`updateIntervalInSeconds: 1`)