### PR TITLE
fix(security): pin Sync Box TLS to Philips's Sync Box CA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ npm run release                # Build and run semantic-release
   - Communicates with Philips Hue Sync Box HTTPS API
   - Uses async-lock to prevent concurrent requests
   - Includes retry logic (3 retries with exponential backoff)
-  - Accepts self-signed certificates (rejectUnauthorized: false)
+  - Pins TLS connections to Philips's Sync Box CA (`src/lib/hsb-ca-cert.ts`); hostname/CN verification is skipped since each box's cert CN is its device id, not its IP (see `createSyncBoxAgent()`)
   - Methods: `getState()`, `updateExecution()`, `updateHue()`
 
 ### State Management
@@ -154,7 +154,7 @@ Override `handlePowerCharacteristicSet()` or add new characteristic handlers. Al
 
 - This is an **ES2022 module** project - use `.js` extensions in import statements
 - The plugin uses **strict TypeScript** mode (except `noImplicitAny: false`)
-- Sync Box API uses **self-signed certificates** - certificate validation is disabled
+- Sync Box API uses **certificates signed by Philips's Sync Box CA** - the chain is validated but hostname verification is skipped (see `SyncBoxClient`)
 - API requests are **serialized** via async-lock to prevent conflicts
 - TV accessories are **external** and require manual HomeKit pairing
 - The platform uses **Homebridge's dynamic platform API** for accessory management

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -15,6 +15,7 @@ import {
   SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS,
 } from './constants.js';
 import { isValidState } from './validation.js';
+import { HSB_CA_CERT } from './hsb-ca-cert.js';
 
 const fetch = fetch_retry(originalFetch, {
   retries: HTTP_RETRY_COUNT,
@@ -36,6 +37,20 @@ const fetch = fetch_retry(originalFetch, {
   },
 });
 
+// Trusts only certs signed by Philips's Sync Box CA, but skips hostname
+// verification: each box's leaf cert has its uniqueId as the CN, not its IP,
+// and this plugin has no discovery step to learn that id ahead of connecting.
+// This still rejects arbitrary/self-signed certs from an untrusted LAN host -
+// it just can't distinguish this Sync Box's cert from another genuine one.
+export function createSyncBoxAgent(): https.Agent {
+  return new https.Agent({
+    ca: HSB_CA_CERT,
+    rejectUnauthorized: true,
+    checkServerIdentity: () => undefined,
+    keepAlive: true,
+  });
+}
+
 export class SyncBoxClient {
   private readonly LOCK_KEY = 'sync-box';
   private readonly LOCK_OPTIONS: AsyncLockOptions = {
@@ -44,10 +59,7 @@ export class SyncBoxClient {
   };
 
   private readonly lock: AsyncLock;
-  private readonly agent = new https.Agent({
-    rejectUnauthorized: false,
-    keepAlive: true,
-  });
+  private readonly agent = createSyncBoxAgent();
 
   constructor(
     private readonly log: Logger | Console,
@@ -137,11 +149,12 @@ export class SyncBoxClient {
       return null as T;
     }
     const json = await res.json();
-    // The Sync Box's cert is accepted without identity verification
-    // (rejectUnauthorized: false), so a LAN-adjacent attacker able to spoof
-    // its responses must not be able to hand every accessory's update() a
-    // shape it dereferences unconditionally - that already crashed the
-    // entire Homebridge process, not just this plugin's accessories.
+    // Any host with a cert signed by Philips's Sync Box CA is accepted
+    // regardless of hostname (see createSyncBoxAgent), so a LAN-adjacent
+    // attacker with a genuine Sync Box's cert must not be able to hand every
+    // accessory's update() a shape it dereferences unconditionally - that
+    // already crashed the entire Homebridge process, not just this plugin's
+    // accessories.
     if (!isValidState(json)) {
       throw new Error('Sync Box returned a malformed state response.');
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -87,8 +87,9 @@ export const MAX_API_BODY_BYTES = 100_000;
 export const API_REQUEST_TIMEOUT_MS = 10_000;
 
 // ===== Sync Box Client Security Constants =====
-// The Sync Box's cert is accepted without identity verification, so a
-// LAN-adjacent attacker able to spoof its address could otherwise return an
-// unbounded body and exhaust the shared Homebridge process's heap before
-// isValidState() ever runs. Legitimate state responses are a few KB.
+// Hostname isn't checked on the Sync Box's cert (see createSyncBoxAgent), so
+// a LAN-adjacent attacker with any cert signed by Philips's Sync Box CA could
+// otherwise return an unbounded body and exhaust the shared Homebridge
+// process's heap before isValidState() ever runs. Legitimate state responses
+// are a few KB.
 export const MAX_SYNC_BOX_RESPONSE_BYTES = 100_000;

--- a/src/lib/hsb-ca-cert.ts
+++ b/src/lib/hsb-ca-cert.ts
@@ -1,0 +1,18 @@
+// Root CA that signs every Hue Sync Box's HTTPS leaf certificate. Shared across
+// all Sync Box devices (baked into the firmware) - it is not specific to any one
+// box, so it authenticates "a genuine Sync Box" rather than "this exact device".
+// Source: https://developers.meethue.com/wp-content/uploads/2020/01/hsb_cacert.pem_.txt
+// Documented at: https://developers.meethue.com/develop/hue-entertainment/hue-hdmi-sync-box-api/#HTTPS
+export const HSB_CA_CERT = `-----BEGIN CERTIFICATE-----
+MIIBwDCCAWagAwIBAgIBATAKBggqhkjOPQQDAjA2MQswCQYDVQQGEwJOTDEUMBIG
+A1UECgwLUGhpbGlwcyBIdWUxETAPBgNVBAMMCHJvb3QtaHNiMCAXDTE3MDEwMTAw
+MDAwMFoYDzk5OTkxMjMxMjM1OTU5WjA2MQswCQYDVQQGEwJOTDEUMBIGA1UECgwL
+UGhpbGlwcyBIdWUxETAPBgNVBAMMCHJvb3QtaHNiMFkwEwYHKoZIzj0CAQYIKoZI
+zj0DAQcDQgAEr9FgOxnsonsrnUZr3C4ggST7YCR9wISvDuwlNdZcAz4HiVCNmAAP
+tAnAFDG0U19Rmc4MfRYBMO8GrOHrOkZ7sKNjMGEwHQYDVR0OBBYEFCK+VIWZqp++
+DHqmGLWEZHYdH9v7MB8GA1UdIwQYMBaAFCK+VIWZqp++DHqmGLWEZHYdH9v7MA8G
+A1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49BAMCA0gAMEUC
+IAFDI0Q4IOPxV7cY4wSVOJAn4y5AdZwrItJ1XuNpmCltAiEA5c6wcu6qmF596uyA
+r7xLnr3/F5zJxrE3AyLD4t+5oKs=
+-----END CERTIFICATE-----
+`;

--- a/test/unit/lib/client.test.ts
+++ b/test/unit/lib/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import type { HueSyncBoxPlatformConfig } from '../../../src/config.js';
 import type { State } from '../../../src/state.js';
+import { HSB_CA_CERT } from '../../../src/lib/hsb-ca-cert.js';
 
 const mockFetch = jest.fn();
 
@@ -11,7 +12,8 @@ jest.unstable_mockModule('node-fetch', () => ({
   default: mockFetch,
 }));
 
-const { SyncBoxClient } = await import('../../../src/lib/client.js');
+const { SyncBoxClient, createSyncBoxAgent } =
+  await import('../../../src/lib/client.js');
 const { HTTP_RETRY_BASE_DELAY_MS, MAX_SYNC_BOX_RESPONSE_BYTES } =
   await import('../../../src/lib/constants.js');
 
@@ -205,5 +207,23 @@ describe('SyncBoxClient', () => {
     const result = await client.getState();
 
     expect(result).toEqual(validState);
+  });
+});
+
+describe('createSyncBoxAgent', () => {
+  it('pins to the Sync Box CA and requires the chain to validate', () => {
+    const agent = createSyncBoxAgent();
+    expect(agent.options.ca).toBe(HSB_CA_CERT);
+    expect(agent.options.rejectUnauthorized).toBe(true);
+  });
+
+  it('skips hostname verification since leaf certs are keyed by device id, not IP', () => {
+    const agent = createSyncBoxAgent();
+    const checkServerIdentity = agent.options
+      .checkServerIdentity as unknown as (
+      hostname: string,
+      cert: unknown
+    ) => Error | undefined;
+    expect(checkServerIdentity('192.168.1.50', {} as never)).toBeUndefined();
   });
 });

--- a/test/unit/lib/hsb-ca-cert.test.ts
+++ b/test/unit/lib/hsb-ca-cert.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from '@jest/globals';
+import { X509Certificate } from 'node:crypto';
+import { HSB_CA_CERT } from '../../../src/lib/hsb-ca-cert.js';
+
+describe('HSB_CA_CERT', () => {
+  it('parses as a valid, self-signed X.509 certificate', () => {
+    const cert = new X509Certificate(HSB_CA_CERT);
+    expect(cert.issuer).toBe(cert.subject);
+    expect(cert.checkIssued(cert)).toBe(true);
+  });
+
+  it('identifies Philips Hue as the issuer of the Sync Box root CA', () => {
+    const cert = new X509Certificate(HSB_CA_CERT);
+    expect(cert.subject).toContain('O=Philips Hue');
+    expect(cert.subject).toContain('CN=root-hsb');
+  });
+
+  it('is marked as a CA certificate', () => {
+    const cert = new X509Certificate(HSB_CA_CERT);
+    expect(cert.ca).toBe(true);
+  });
+
+  it('is currently valid', () => {
+    const cert = new X509Certificate(HSB_CA_CERT);
+    const now = Date.now();
+    expect(new Date(cert.validFrom).getTime()).toBeLessThan(now);
+    expect(new Date(cert.validTo).getTime()).toBeGreaterThan(now);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `rejectUnauthorized: false` in `SyncBoxClient` with pinning to Philips's Sync Box root CA (`root-hsb`, bundled from https://developers.meethue.com/wp-content/uploads/2020/01/hsb_cacert.pem_.txt), so only certs actually signed by Philips are trusted instead of any cert.
- Hostname/CN verification is intentionally skipped: each Sync Box's leaf cert CN is its device `uniqueId`, not its IP, and this plugin has no discovery step to learn that id ahead of connecting (confirmed against `Device.uniqueId` in `src/state.ts` and Philips's own `curl --resolve` example). This still blocks arbitrary/self-signed spoofing from a LAN-adjacent host; it can't distinguish this Sync Box's cert from another genuine Sync Box's cert.
- Updated the stale security comments in `client.ts`/`constants.ts` and `CLAUDE.md` that referenced the old `rejectUnauthorized: false` behavior.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run prettier` (new files only — two pre-existing unrelated formatting warnings left untouched)
- [x] `npm test` (82/82 passing, including new `hsb-ca-cert.test.ts` and `client.test.ts`)
- [ ] Manual verification against a real Sync Box (I don't have hardware access — please confirm connectivity still works before merging)