### PR TITLE
fix(release): correct branches config typo, backfill missing changelog bodies

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branch": [
+  "branches": [
     "main",
     "next",
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ All notable changes to this project will be documented in this file. See
 
 ## [3.0.4](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.3...v3.0.4) (2026-07-17)
 
+### Bug Fixes
+
+* **client:** bound Sync Box requests and stop polling overlap ([#435](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/435)) ([aa22562](https://github.com/jabrown93/homebridge-philips-hue-sync-box/commit/aa22562b0a74e3993c5a981206d7b5b5e0fb26f6)), closes [#431](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/431)
+* **security:** prevent process-wide crashes from api-server and Sync Box response handling ([#434](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/434)) ([c48e4da](https://github.com/jabrown93/homebridge-philips-hue-sync-box/commit/c48e4da50f1332d9d5d669646f992c2dad54575b))
+
 ## [3.0.3](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.2...v3.0.3) (2026-07-16)
 
+### Bug Fixes
+
+* **security:** close API server DoS, secret-leak, and validation gaps ([#429](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/429)) ([735f4bc](https://github.com/jabrown93/homebridge-philips-hue-sync-box/commit/735f4bc521756459706889e8db3520bc66093f39))
+
 ## [3.0.2](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.1...v3.0.2) (2026-06-30)
+
+### Bug Fixes
+
+* rename issue chooser config to config.yml ([#421](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/421)) ([9145feb](https://github.com/jabrown93/homebridge-philips-hue-sync-box/commit/9145febe00990cea136d26c3e1b97572ff244f91))
 
 ## [3.0.1](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.0...v3.0.1) (2026-06-17)
 


### PR DESCRIPTION
## Summary
- `.releaserc.json` has used the key `"branch"` instead of semantic-release's actual `"branches"` option since it was added. `get-config.js` only reads `options.branches` (plural), so this whole custom block has been silently ignored the entire time -- semantic-release has been running on its own built-in default branch list (`main`, `master`, `next`, `next-major`, `beta`\*, `alpha`\*, plus a maintenance-branch glob). It happened to resolve to the same effective set here (only `main`/`beta` exist as real branches, so behavior matched what was intended), but it's a real correctness bug: an `alpha` branch, if ever created, would silently not release, since `alpha` isn't in semantic-release's built-in defaults.
- Backfill the `v3.0.2`, `v3.0.3`, and `v3.0.4` CHANGELOG.md entries. All three landed as heading-only stubs with no "Bug Fixes" body, despite each commit range containing real `fix:` commits (confirmed via the actual CI logs: commit-analyzer correctly classified each as `patch`). I replayed semantic-release's actual `commit-analyzer` + `release-notes-generator` locally against the exact historical commit ranges, exact plugin config, and even the exact dependency versions pinned at the time -- notes generation produced correct output every time, so the empty bodies in production were not caused by the commits, the config, or dependency versions. I could not pin down the exact live-CI trigger despite extensive reproduction attempts; this PR backfills the correct (verified) content rather than blocking on root-causing an intermittent CI issue.

## Test plan
- [x] `.releaserc.json` is valid JSON
- [x] Backfilled notes were generated by directly invoking `@semantic-release/commit-analyzer` + `@semantic-release/release-notes-generator` against each historical commit range (`v3.0.1..v3.0.2`, `v3.0.2..v3.0.3`, `v3.0.3..v3.0.4`), matching the content and commit links they should have produced
- [ ] Next real release run picks up the corrected `branches` config with no behavior change (main/beta still resolve to `release`/`prerelease` types respectively)