### PR TITLE
fix(release): restore changelog bodies by pinning conventionalcommits to v9

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,4 @@ node_modules
 dist
 package-lock.json
 CHANGELOG.md
-bom.cdx.json
+sbom.cdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file. See
 
 ## [3.0.5](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.4...v3.0.5) (2026-07-17)
 
-## [3.0.5](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.4...v3.0.5) (2026-07-17)
+### Bug Fixes
+
+* **release:** correct branches config typo, backfill missing changelog bodies ([#438](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/438)) ([3fb7eb4](https://github.com/jabrown93/homebridge-philips-hue-sync-box/commit/3fb7eb4ee67f2081db6b9e169d88bf8fb5feebd0))
 
 ## [3.0.4](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.3...v3.0.4) (2026-07-17)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@types/node": "24.13.3",
         "@typescript-eslint/eslint-plugin": "8.64.0",
         "@typescript-eslint/parser": "8.64.0",
-        "conventional-changelog-conventionalcommits": "10.2.1",
+        "conventional-changelog-conventionalcommits": "9.3.1",
         "cross-env": "10.1.0",
         "eslint": "10.7.0",
         "homebridge": "2.1.1",
@@ -675,6 +675,19 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -6227,16 +6240,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@types/node": "24.13.3",
     "@typescript-eslint/eslint-plugin": "8.64.0",
     "@typescript-eslint/parser": "8.64.0",
-    "conventional-changelog-conventionalcommits": "10.2.1",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "cross-env": "10.1.0",
     "eslint": "10.7.0",
     "homebridge": "2.1.1",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jabrown93/.github//renovate-config.json"]
+  "extends": ["github>jabrown93/.github//renovate-config.json"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+      "allowedVersions": "<10.0.0",
+      "description": "Pinned to v9: v10 builds writerOpts from @conventional-changelog/template JS functions that require conventional-changelog-writer v9, but @semantic-release/release-notes-generator pins conventional-changelog-writer ^8 and silently ignores them, producing heading-only CHANGELOG entries with no commit bodies. Unpin once release-notes-generator supports writer v9."
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

Every release since `3.0.2` landed a **heading-only** CHANGELOG entry with no commit bodies:

```
## [3.0.5](.../compare/v3.0.4...v3.0.5) (2026-07-17)

## [3.0.4](.../compare/v3.0.3...v3.0.4) (2026-07-17)
```

#438 backfilled `3.0.2`–`3.0.4` by hand but explicitly could not identify the root cause ("root cause in the live CI run remains unconfirmed"). This is that root cause.

## Root cause

Not `@semantic-release/changelog` — that plugin faithfully wrote the empty string it was handed. The `ci(release): 3.0.5` **commit message** (`${nextRelease.notes}`) was *already* empty, proving the notes were empty before `changelog` or the `sed` ever ran.

`conventional-changelog-conventionalcommits` **v10** builds its `writerOpts` from `@conventional-changelog/template` JS functions, which require `conventional-changelog-writer` **v9**. `@semantic-release/release-notes-generator@14.1.1` (latest) pins `conventional-changelog-writer@^8`, which cannot consume them — it silently discards the preset's `template`/`transform`, falls back to its **own default header template**, and drops every commit.

Nothing errors. You just get a bare heading. That's why it looked like a flake, and why replaying the plugins directly didn't reproduce it.

The default writer v8 header template is `## [{{version}}]({{compareUrlFormat}}) ({{date}})` — exactly the stub.

## Timeline

| Date | Event |
|---|---|
| 2026-06-17 | `3.0.1` — last release **with** a body |
| 2026-06-30 | #418 bumps the preset v9 → **v10** |
| 2026-06-30 | `3.0.2` — **first stub** |

## Verification

Replayed the real `@semantic-release/release-notes-generator` against the real `v3.0.4..3fb7eb4` commit range:

| Preset | Output |
|---|---|
| **10.2.1** | `"## [3.0.5](...) (2026-07-17)\n"` — byte-identical to the stub in `CHANGELOG.md` |
| **9.3.1** | `"## [3.0.5](...)\n\n### Bug Fixes\n\n* **release:** ..."` ✅ |

## Changes

- Pin `conventional-changelog-conventionalcommits` to `9.3.1`. `@commitlint/config-conventional` requires `^10.0.0` and resolves its own nested v10; it only uses the parser, so it is unaffected.
- Renovate rule blocking v10 until `release-notes-generator` supports writer v9. Renovate is what introduced this in the first place, so without the rule it would silently regress again.
- **Correct `.prettierignore`**: #439 added `bom.cdx.json`, but `.releaserc.json` generates `sbom.cdx.json`. Prettier ignore uses gitignore syntax, so the entry never matched — `prepublishOnly`'s `prettier --check` would still have failed the next release on the generated SBOM. Verified: with an unformatted `sbom.cdx.json` present, `prettier --check .` now passes.

`npm run format` across the repo produced no further changes.

Tests: 85 passed / 6 suites.

## Note

There is no upstream fix to wait for — `release-notes-generator@14.1.1` is the latest and still pins writer `^8`.

The same borked combo exists in `homebridge-onkyo` (already shipped a stub at `1.5.2`), `homebridge-smartrent`, and `homebridge-playstation` (both latent — they'll stub on their next release). Separate PRs follow.