### PR TITLE
ci(release): build in prepack instead of gating publish on checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "compile": "tsc",
     "build": "npm-run-all clean test compile typecheck",
     "watch": "npm run setup-config && npm run build && npm link && nodemon",
-    "prepublishOnly": "npm-run-all prettier lint test build",
+    "prepack": "npm-run-all clean compile",
     "semantic-release": "cross-env semantic-release --no-ci",
     "release": "npm-run-all build semantic-release",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",


### PR DESCRIPTION
Follow-up to #440. That PR fixed the *trigger*; this one fixes the *structure*.

## Problem

`prepublishOnly` runs `prettier`, `lint`, `test` and `build` **inside `npm publish`**. That's the worst possible place for a quality gate.

By the time `npm publish` runs, the release is already public:

1. `@semantic-release/git` commits the release and **pushes** — during `prepare`
2. semantic-release creates and **pushes the tag** — before the publish plugins run
3. *then* `npm publish` runs `prepublishOnly`

So anything `prepublishOnly` rejects fails **after** the tag, CHANGELOG entry and version bump have already landed — and npm never gets the package. The repo ends up claiming a release that doesn't exist.

That's exactly what happened here: `3.0.0`–`3.0.5` were all tagged and changelogged while npm's `latest` sat on `2.3.0`. One `prettier` warning on a generated `sbom.cdx.json` did it.

#440 fixed that specific trigger — **3.0.6 published successfully**, the first 3.x ever to reach npm. But the fragility is structural: any future lint or formatting failure half-releases the package the same way.

## Fix

Move the build to **`prepack`** — the hook that actually needs to run. npm fires it for both code paths semantic-release uses:

| semantic-release step | npm command | hooks fired |
|---|---|---|
| `prepare` (tarballDir) | `npm pack` | `prepack` |
| `publish` | `npm publish` | `prepublishOnly` → `prepack` |

```diff
-  "prepublishOnly": "npm-run-all prettier lint test build",
+  "prepack": "npm-run-all clean compile",
```

Publishing now only produces the artifact and cannot fail on style. `clean`+`compile` is sufficient — `tsc` type-checks as it emits, so a separate `typecheck` pass adds nothing to the publish path.

## The checks are not dropped

- `lint` and `build` (which runs `test` and `typecheck`) already run in CI via `node-build.yml`.
- `prettier` did **not** — CI ran lint and build but never prettier. Added in jabrown93/.github#24.

The pre-commit hook alone isn't enough: it's bypassable with `--no-verify` and doesn't cover Renovate or web-UI commits — which is how an unformatted `pr-license-comment.yml` reached `main` in four repos at once.

## Verification

With `dist/` deleted and a deliberate prettier violation present:

```
pack exit: 0
dist files: 76
dist/index.js present: 1   <- the `main` entry
total files: 101
```

`npm pack` builds `dist` and packs the `main` entry at exit 0, without running prettier. Tests: 85 passed / 6 suites.

## Sequencing

This is safe to merge before jabrown93/.github#24 — the only gap is that prettier is briefly unenforced in CI (it's already unenforced on PRs today, so this is no worse). Ideal order:

1. jabrown93/.github#24 → tag `v1.3.0`
2. re-pin `node-build.yml` here (Renovate will offer it)
3. this PR