### PR TITLE
chore(package): standardize npm scripts and metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "type": "module",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "src",
     "dist",

--- a/package.json
+++ b/package.json
@@ -39,14 +39,13 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "typecheck": "tsc --noEmit",
     "prettier": "prettier --check .",
     "format": "prettier --write .",
     "lint": "eslint src/**.ts",
     "lint:fix": "eslint src/**.ts --fix",
     "clean": "rimraf ./dist",
     "compile": "tsc",
-    "build": "npm-run-all clean test compile typecheck",
+    "build": "npm-run-all clean test compile",
     "watch": "npm run setup-config && npm run build && npm link && nodemon",
     "prepack": "npm-run-all clean compile",
     "semantic-release": "cross-env semantic-release --no-ci",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jabrown93/homebridge-philips-hue-sync-box.git"
+    "url": "git+https://github.com/jabrown93/homebridge-philips-hue-sync-box.git"
   },
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "compile": "tsc",
     "build": "npm-run-all clean test compile",
     "watch": "npm run setup-config && npm run build && npm link && nodemon",
-    "prepack": "npm-run-all clean compile",
     "semantic-release": "cross-env semantic-release --no-ci",
     "release": "npm-run-all build semantic-release",
     "test": "vitest run",
@@ -56,7 +55,8 @@
     "test:coverage": "vitest run --coverage",
     "prepare": "husky",
     "tsc": "tsc --noEmit",
-    "setup-config": "if [ ! -f ./test/hbConfig/config.json ]; then cp ./test/hbConfig/config-template.json ./test/hbConfig/config.json; fi"
+    "setup-config": "if [ ! -f ./test/hbConfig/config.json ]; then cp ./test/hbConfig/config-template.json ./test/hbConfig/config.json; fi",
+    "prepack": "npm-run-all clean compile"
   },
   "prettier": "@jabrown93/dev-config/prettier",
   "dependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['test/**/*.{test,spec}.ts'],
+    include: ['test/unit/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary
- Removes the duplicate `typecheck` script (identical to `tsc`) and drops the now-nonexistent `typecheck` step from `build`'s step list
- Declares `types` (dist/index.d.ts, safe: dev-config's shared tsconfig sets `declaration: true`)
- Uses `git+https://` for the repository URL (was a bare `https://` URL missing the `git+` scheme prefix)
- Moves `prepack` to the end of the scripts block to match the other three plugins' ordering (cosmetic)
- Narrows `vitest.config.ts`'s include glob from `test/**/*.{test,spec}.ts` to `test/unit/**/*.test.ts` — matches smartrent exactly now that both use the same test-naming convention

Part of a fleet-wide package.json cleanup pass across the homebridge-* plugins. Note: this repo isn't a fork (`isFork: false`), so `MIT` remains fully your call — untouched here.

## Test plan
- [x] `package.json`/`vitest.config.ts` validated as well-formed