### PR TITLE
refactor: simplify accessories, client, and platform

### DIFF
--- a/src/accessories/base.ts
+++ b/src/accessories/base.ts
@@ -154,11 +154,17 @@ export abstract class SyncBoxDevice {
     );
   }
 
-  protected shouldBeOn(): boolean {
+  // True when the box is actively syncing (video/music/game), as opposed to
+  // sitting in passthrough or powersave.
+  protected isSyncActive(): boolean {
     return (
       this.state.execution.mode !== POWER_SAVE &&
       this.state.execution.mode !== PASSTHROUGH
     );
+  }
+
+  protected shouldBeOn(): boolean {
+    return this.isSyncActive();
   }
 
   protected getSuffix(): string {

--- a/src/accessories/base.ts
+++ b/src/accessories/base.ts
@@ -102,10 +102,7 @@ export abstract class SyncBoxDevice {
     // Saves the changes
     if (newValue) {
       this.platform.log.debug('Switch state to ON');
-      mode = this.platform.config.defaultOnMode;
-      if (mode === MODE_LAST_SYNC) {
-        mode = this?.state?.execution?.lastSyncMode || MODE_VIDEO;
-      }
+      mode = this.getOnMode();
     } else {
       this.platform.log.debug('Switch state to OFF');
       mode = this.platform.config.defaultOffMode;
@@ -113,6 +110,16 @@ export abstract class SyncBoxDevice {
     return this.updateExecution({
       mode,
     });
+  }
+
+  // Resolves the configured default on-mode, falling back to video when
+  // 'lastSyncMode' is configured but the box has not synced yet.
+  protected getOnMode(): string {
+    const mode = this.platform.config.defaultOnMode;
+    if (mode !== MODE_LAST_SYNC) {
+      return mode;
+    }
+    return this.state.execution.lastSyncMode || MODE_VIDEO;
   }
 
   protected updateExecution(execution: Partial<Execution>) {

--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -206,10 +206,7 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
 
       case this.platform.api.hap.Characteristic.RemoteKey.PLAY_PAUSE:
         this.platform.log.debug('Toggle switch state');
-        if (
-          this.state.execution.mode !== POWER_SAVE &&
-          this.state.execution.mode !== PASSTHROUGH
-        ) {
+        if (this.isSyncActive()) {
           this.updateExecution({
             mode: this.platform.config.defaultOffMode,
           });
@@ -287,8 +284,7 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     this.platform.log.debug('Updated state to ' + this.state.execution.mode);
     this.lightbulbService.updateCharacteristic(
       this.platform.api.hap.Characteristic.On,
-      this.state.execution.mode !== POWER_SAVE &&
-        this.state.execution.mode !== PASSTHROUGH
+      this.isSyncActive()
     );
     this.platform.log.debug(
       'Updated brightness to ' + this.state.execution.brightness
@@ -373,16 +369,10 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
   }
 
   protected getMode() {
-    let mode = MODE_VIDEO;
-    if (
-      this.state.execution.mode !== POWER_SAVE &&
-      this.state.execution.mode !== PASSTHROUGH
-    ) {
-      mode = this.state.execution.mode;
-    } else if (this.state.execution.lastSyncMode) {
-      mode = this.state.execution.lastSyncMode;
+    if (this.isSyncActive()) {
+      return this.state.execution.mode;
     }
-    return mode;
+    return this.state.execution.lastSyncMode || MODE_VIDEO;
   }
 
   protected abstract getConfiguredNamePropertyName(): string;

--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -124,8 +124,6 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
       this.accessory.getService(this.platform.api.hap.Service.Lightbulb) ||
       this.accessory.addService(this.platform.api.hap.Service.Lightbulb);
 
-    // Stores the light bulb service
-
     // Subscribes for changes of the on characteristic
     this.lightbulbService
       .getCharacteristic(this.platform.api.hap.Characteristic.On)

--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -24,6 +24,8 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
   protected inputServices: Service[] = [];
   protected mainAccessory?: PlatformAccessory;
 
+  // The numbers double as HomeKit input identifiers, so the order is part of
+  // the accessory's UI. The reverse maps are derived to keep them in sync.
   protected readonly intensityToNumber: Map<string, number> = new Map([
     ['subtle', 1],
     ['moderate', 2],
@@ -31,12 +33,12 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     ['intense', 4],
   ]);
 
-  protected readonly numberToIntensity: Map<number, string> = new Map([
-    [1, 'subtle'],
-    [2, 'moderate'],
-    [3, 'high'],
-    [4, 'intense'],
-  ]);
+  protected readonly numberToIntensity: Map<number, string> = new Map(
+    [...this.intensityToNumber].map(([intensity, number]) => [
+      number,
+      intensity,
+    ])
+  );
 
   protected readonly modeToNumber: Map<string, number> = new Map([
     [MODE_VIDEO, 1],
@@ -46,13 +48,9 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     [POWER_SAVE, 5],
   ]);
 
-  protected readonly numberToMode: Map<number, string> = new Map([
-    [1, MODE_VIDEO],
-    [2, MODE_MUSIC],
-    [3, MODE_GAME],
-    [4, PASSTHROUGH],
-    [5, POWER_SAVE],
-  ]);
+  protected readonly numberToMode: Map<number, string> = new Map(
+    [...this.modeToNumber].map(([mode, number]) => [number, mode])
+  );
 
   protected constructor(
     protected readonly platform: HueSyncBoxPlatform,

--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -166,7 +166,6 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
   protected handleRemoteButton(value: CharacteristicValue) {
     this.platform.log.debug('Remote key pressed: ' + value);
 
-    let mode: string;
     switch (value) {
       case this.platform.api.hap.Characteristic.RemoteKey.ARROW_UP:
         this.platform.log.debug('Increase brightness by 25%');
@@ -188,57 +187,13 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
         });
         break;
 
-      case this.platform.api.hap.Characteristic.RemoteKey.ARROW_LEFT: {
-        // Gets the current mode or the last sync mode to set the intensity
-        mode = this.getMode();
-
-        this.platform.log.debug('Toggle intensity');
-        if (!this.state.execution[mode]) {
-          this.platform.log.debug(
-            'Current mode ' + mode + ' does not have an intensity to update'
-          );
-          break;
-        }
-        const currentIntensity = this.state.execution[mode].intensity;
-        const nextLowestIntensity =
-          (this.intensityToNumber.get(currentIntensity) ?? 4) - 1;
-        if (nextLowestIntensity < 1) {
-          break;
-        }
-        const nextIntensity = this.numberToIntensity.get(nextLowestIntensity);
-        const body = {};
-        body[mode] = {
-          intensity: nextIntensity,
-        };
-        this.updateExecution(body);
+      case this.platform.api.hap.Characteristic.RemoteKey.ARROW_LEFT:
+        this.stepIntensity(-1);
         break;
-      }
 
-      case this.platform.api.hap.Characteristic.RemoteKey.ARROW_RIGHT: {
-        // Gets the current mode or the last sync mode to set the intensity
-        mode = this.getMode();
-
-        this.platform.log.debug('Toggle intensity');
-        if (!this.state.execution[mode]) {
-          this.platform.log.debug(
-            'Current mode ' + mode + ' does not have an intensity to update'
-          );
-          break;
-        }
-        const currentIntensity = this.state.execution[mode].intensity;
-        const nextHighestIntensity =
-          (this.intensityToNumber.get(currentIntensity) ?? 1) + 1;
-        if (nextHighestIntensity > 4) {
-          break;
-        }
-        const nextIntensity = this.numberToIntensity.get(nextHighestIntensity);
-        const body = {};
-        body[mode] = {
-          intensity: nextIntensity,
-        };
-        this.updateExecution(body);
+      case this.platform.api.hap.Characteristic.RemoteKey.ARROW_RIGHT:
+        this.stepIntensity(1);
         break;
-      }
 
       case this.platform.api.hap.Characteristic.RemoteKey.SELECT: {
         this.platform.log.debug('Toggle mode');
@@ -282,6 +237,30 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
         break;
       }
     }
+  }
+
+  // An unknown current intensity falls back so the step still lands on a
+  // valid value: stepping down assumes 'intense' (4), stepping up 'subtle' (1).
+  private stepIntensity(direction: -1 | 1): void {
+    // Gets the current mode or the last sync mode to set the intensity
+    const mode = this.getMode();
+
+    this.platform.log.debug('Toggle intensity');
+    if (!this.state.execution[mode]) {
+      this.platform.log.debug(
+        'Current mode ' + mode + ' does not have an intensity to update'
+      );
+      return;
+    }
+    const currentIntensity = this.state.execution[mode].intensity;
+    const fallback = direction === -1 ? 4 : 1;
+    const nextIntensity = this.numberToIntensity.get(
+      (this.intensityToNumber.get(currentIntensity) ?? fallback) + direction
+    );
+    if (!nextIntensity) {
+      return;
+    }
+    this.updateExecution({ [mode]: { intensity: nextIntensity } });
   }
 
   protected updateSources(services: Service[]) {

--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -22,7 +22,6 @@ import { convertSyncBoxToHomekit } from '../lib/brightness.js';
 export abstract class BaseTvDevice extends SyncBoxDevice {
   protected lightbulbService?: Service;
   protected inputServices: Service[] = [];
-  protected mainAccessory?: PlatformAccessory;
 
   // The numbers double as HomeKit input identifiers, so the order is part of
   // the accessory's UI. The reverse maps are derived to keep them in sync.
@@ -56,10 +55,9 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     protected readonly platform: HueSyncBoxPlatform,
     public readonly accessory: PlatformAccessory,
     protected state: State,
-    protected primaryAccessory?: PlatformAccessory
+    protected mainAccessory?: PlatformAccessory
   ) {
     super(platform, accessory, state);
-    this.mainAccessory = primaryAccessory;
 
     this.createInputServices();
     this.createLightbulbService();
@@ -72,16 +70,11 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
       .getCharacteristic(this.platform.api.hap.Characteristic.RemoteKey)
       .onSet(this.handleRemoteButton.bind(this));
 
-    let name;
-    if (this.platform.config[this.getConfiguredNamePropertyName()]) {
-      name = this.platform.config[this.getConfiguredNamePropertyName()];
-    } else if (
-      this.mainAccessory?.context[this.getConfiguredNamePropertyName()]
-    ) {
-      name = this.mainAccessory?.context[this.getConfiguredNamePropertyName()];
-    } else {
-      name = this.state.device.name;
-    }
+    const nameProperty = this.getConfiguredNamePropertyName();
+    const name =
+      this.platform.config[nameProperty] ||
+      this.mainAccessory?.context[nameProperty] ||
+      this.state.device.name;
     this.service
       .getCharacteristic(this.platform.api.hap.Characteristic.ConfiguredName)
       .onSet(this.handleConfiguredNameChange.bind(this));
@@ -92,20 +85,19 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
   }
 
   protected handleConfiguredNameChange(value: CharacteristicValue) {
-    if (this.platform.config[this.getConfiguredNamePropertyName()]) {
+    const nameProperty = this.getConfiguredNamePropertyName();
+    if (this.platform.config[nameProperty]) {
       this.platform.log.warn(
-        this.getConfiguredNamePropertyName() +
+        nameProperty +
           ' is set in the config, therefore it cannot be changed by HomeKit.' +
           ' Please change it in the Homebridge config. Alternatively remove the' +
           ' config and manually configure in HomeKit (not recommended).'
       );
       return;
     }
-    this.platform.log.debug(
-      this.getConfiguredNamePropertyName() + ' name changed to ' + value
-    );
+    this.platform.log.debug(nameProperty + ' name changed to ' + value);
     if (this.mainAccessory) {
-      this.mainAccessory.context[this.getConfiguredNamePropertyName()] = value;
+      this.mainAccessory.context[nameProperty] = value;
     }
   }
 

--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -13,7 +13,6 @@ import {
   MODE_VIDEO,
   MODE_MUSIC,
   MODE_GAME,
-  MODE_LAST_SYNC,
   BRIGHTNESS_MAX_SYNCBOX,
   BRIGHTNESS_STEP_SYNCBOX,
   BRIGHTNESS_MIN,
@@ -215,13 +214,8 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
             mode: this.platform.config.defaultOffMode,
           });
         } else {
-          let onMode: string = this.platform.config.defaultOnMode;
-          if (onMode === MODE_LAST_SYNC) {
-            onMode = this?.state?.execution?.lastSyncMode ?? MODE_VIDEO;
-          }
-
           this.updateExecution({
-            mode: onMode,
+            mode: this.getOnMode(),
           });
         }
         break;

--- a/src/accessories/entertainmentTv.ts
+++ b/src/accessories/entertainmentTv.ts
@@ -15,8 +15,9 @@ export class EntertainmentTvDevice extends BaseTvDevice {
       .getCharacteristic(this.platform.api.hap.Characteristic.ActiveIdentifier)
       .onSet(value => {
         // The identifier is the group's 1-based position in the groups object
-        const groupId =
-          Object.keys(this.state.hue.groups)[(value as number) - 1];
+        const groupId = Object.keys(this.state.hue.groups)[
+          (value as number) - 1
+        ];
         const group = groupId ? this.state.hue.groups[groupId] : undefined;
         if (!group) {
           return;

--- a/src/accessories/entertainmentTv.ts
+++ b/src/accessories/entertainmentTv.ts
@@ -14,20 +14,11 @@ export class EntertainmentTvDevice extends BaseTvDevice {
     this.service
       .getCharacteristic(this.platform.api.hap.Characteristic.ActiveIdentifier)
       .onSet(value => {
-        // Gets the ID of the group based on the index
-        let groupId: string | null = null;
-        let i = 1;
-        for (const currentGroupId in this.state.hue.groups) {
-          if (i === value) {
-            groupId = currentGroupId;
-            break;
-          }
-          i++;
-        }
-
-        // @ts-expect-error need to use self as a key
-        const group = this.state.hue.groups[groupId];
-        if (!group || !groupId) {
+        // The identifier is the group's 1-based position in the groups object
+        const groupId =
+          Object.keys(this.state.hue.groups)[(value as number) - 1];
+        const group = groupId ? this.state.hue.groups[groupId] : undefined;
+        if (!group) {
           return;
         }
         // Saves the changes
@@ -46,14 +37,11 @@ export class EntertainmentTvDevice extends BaseTvDevice {
   }
 
   updateTv(): void {
-    // Gets the ID of the group based on the index
-    let index = 1;
-    for (const currentGroupId in this.state.hue.groups) {
-      if (currentGroupId === this.state.hue.groupId) {
-        break;
-      }
-      index++;
-    }
+    // Gets the 1-based position of the active group; an unknown groupId
+    // falls past the last input, matching no source
+    const groupIds = Object.keys(this.state.hue.groups);
+    const position = groupIds.indexOf(this.state.hue.groupId);
+    const index = position === -1 ? groupIds.length + 1 : position + 1;
 
     // Updates the input characteristic
     this.service.updateCharacteristic(
@@ -83,19 +71,15 @@ export class EntertainmentTvDevice extends BaseTvDevice {
   }
 
   protected createInputServices(): void {
-    let i = 1;
-    for (const groupId in this.state.hue.groups) {
-      const group = this.state.hue.groups[groupId];
-      const name = group.name;
-      const position = 'AREA ' + i;
-
-      const entertainmentInputService = this.getInputService(name, position);
+    Object.values(this.state.hue.groups).forEach((group, index) => {
+      const entertainmentInputService = this.getInputService(
+        group.name,
+        'AREA ' + (index + 1)
+      );
 
       // Adds the input as a linked service, which is important so that the input is properly displayed in the Home app
       this.service.addLinkedService(entertainmentInputService);
       this.inputServices.push(entertainmentInputService);
-
-      i++;
-    }
+    });
   }
 }

--- a/src/accessories/intensityTv.ts
+++ b/src/accessories/intensityTv.ts
@@ -35,12 +35,6 @@ export class IntensityTvDevice extends BaseTvDevice {
       this.service.addLinkedService(intensityInputService);
       this.inputServices.push(intensityInputService);
     }
-    this.service.setCharacteristic(
-      this.platform.api.hap.Characteristic.SleepDiscoveryMode,
-      this.platform.api.hap.Characteristic.SleepDiscoveryMode
-        .ALWAYS_DISCOVERABLE
-    );
-
     this.updateSources(this.inputServices);
   }
 

--- a/src/accessories/tv.ts
+++ b/src/accessories/tv.ts
@@ -65,17 +65,11 @@ export class TvDevice extends BaseTvDevice {
   protected createInputServices(): void {
     const services: Service[] = [];
     for (let i = HDMI_INPUT_MIN; i <= HDMI_INPUT_MAX; i++) {
-      // Sets the TV name
       const hdmiState: HdmiInput = this.state.hdmi[`input${i}`];
       const hdmiPosition = 'HDMI ' + i;
 
       const hdmiName = hdmiState.name ?? hdmiPosition;
       const hdmiInputService = this.getInputService(hdmiName, hdmiPosition);
-      hdmiInputService
-        .getCharacteristic(
-          this.platform.api.hap.Characteristic.TargetVisibilityState
-        )
-        .onSet(this.setVisibility(hdmiInputService));
       // Adds the input as a linked service, which is important so that the input is properly displayed in the Home app
       this.service.addLinkedService(hdmiInputService);
       services.push(hdmiInputService);

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -68,41 +68,36 @@ export class SyncBoxClient {
     this.lock = new AsyncLock();
   }
 
+  // Serializes all Sync Box requests behind the shared lock.
+  private withLock<T>(task: () => Promise<T>): Promise<T> {
+    return this.lock.acquire(this.LOCK_KEY, task, this.LOCK_OPTIONS);
+  }
+
   public async getState(): Promise<State | null> {
-    return await this.lock
-      .acquire(
-        this.LOCK_KEY,
-        async () => await this.sendRequest<State>('GET', ''),
-        this.LOCK_OPTIONS
-      )
-      .catch(e => {
-        this.log.error('Failed to get state from Sync Box:', e);
-        return null;
-      });
+    try {
+      return await this.withLock(() => this.sendRequest<State>('GET', ''));
+    } catch (e) {
+      this.log.error('Failed to get state from Sync Box:', e);
+      return null;
+    }
   }
 
   public async updateExecution(execution: Partial<Execution>): Promise<void> {
-    return await this.lock
-      .acquire(
-        this.LOCK_KEY,
-        async () => await this.sendRequest<void>('PUT', 'execution', execution),
-        this.LOCK_OPTIONS
-      )
-      .catch(e => {
-        this.log.error('Error updating execution:', e);
-      });
+    try {
+      await this.withLock(() =>
+        this.sendRequest<void>('PUT', 'execution', execution)
+      );
+    } catch (e) {
+      this.log.error('Error updating execution:', e);
+    }
   }
 
   public async updateHue(hue: Partial<Hue>): Promise<void> {
-    return await this.lock
-      .acquire(
-        this.LOCK_KEY,
-        async () => await this.sendRequest<void>('PUT', 'hue', hue),
-        this.LOCK_OPTIONS
-      )
-      .catch(e => {
-        this.log.error('Error updating hue:', e);
-      });
+    try {
+      await this.withLock(() => this.sendRequest<void>('PUT', 'hue', hue));
+    } catch (e) {
+      this.log.error('Error updating hue:', e);
+    }
   }
 
   private async sendRequest<T>(

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -177,27 +177,31 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
     this.log.debug('Discovered state:', this.redactStateForLogging(state));
     const accessories = this.discoverAccessories(state);
     const uuids = accessories.map(accessory => {
-      const uuid = accessory.UUID; // see if an accessory with the same uuid has already been registered and restored from
+      const uuid = accessory.UUID;
+      // see if an accessory with the same uuid has already been registered
+      // and restored from cache
       const existingAccessory = this.existingAccessories.get(uuid);
-      const isMainAccessory = accessory.UUID === this.mainAccessory?.UUID;
-      const isPowerSwitch = accessory.context.kind === POWER_SWITCH_ACCESSORY;
+      const target = existingAccessory ?? accessory;
       if (existingAccessory) {
         this.log.debug(
           'Restoring existing accessory from cache: ',
           existingAccessory.context.kind
         );
-        const device = this.createDevice(existingAccessory, state);
-        this.accessories.set(accessory.UUID, existingAccessory);
-        this.devices.push(device);
-        if (isMainAccessory || isPowerSwitch) {
-          this.api.updatePlatformAccessories([existingAccessory]);
-        }
       } else {
         this.log.info('Registering new accessory:', accessory.context.kind);
-        const device = this.createDevice(accessory, state);
-        this.devices.push(device);
-        this.accessories.set(accessory.UUID, accessory);
-        if (isMainAccessory || isPowerSwitch) {
+      }
+      this.devices.push(this.createDevice(target, state));
+      this.accessories.set(uuid, target);
+
+      // Only the main and power switch accessories are bridged; TVs are
+      // published separately as external accessories.
+      const isBridged =
+        uuid === this.mainAccessory?.UUID ||
+        accessory.context.kind === POWER_SWITCH_ACCESSORY;
+      if (isBridged) {
+        if (existingAccessory) {
+          this.api.updatePlatformAccessories([existingAccessory]);
+        } else {
           this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
             accessory,
           ]);
@@ -219,7 +223,7 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
     });
 
     this.log.debug(
-      `Publishing external ${Array.from(this.externalAccessories.values()).length} accessories`
+      `Publishing external ${this.externalAccessories.size} accessories`
     );
     this.api.publishExternalAccessories(
       PLUGIN_NAME,
@@ -343,12 +347,8 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
       this.api.hap.uuid.generate(kind + uuidSeed)
     );
     if (kind === LIGHTBULB_ACCESSORY) {
-      this.mainAccessory = accessory;
       accessory.category = this.api.hap.Categories.LIGHTBULB;
-    } else if (kind === SWITCH_ACCESSORY) {
-      this.mainAccessory = accessory;
-      accessory.category = this.api.hap.Categories.SWITCH;
-    } else if (kind === POWER_SWITCH_ACCESSORY) {
+    } else if (kind === SWITCH_ACCESSORY || kind === POWER_SWITCH_ACCESSORY) {
       accessory.category = this.api.hap.Categories.SWITCH;
     }
     accessory.context.kind = kind;


### PR DESCRIPTION
## Summary

Behavior-preserving simplification pass over `src/` (net −68 lines, −201/+133). One commit per change, tests + typecheck + lint run after each.

- **baseTv**: extracted `stepIntensity(direction)` from the ~25-line duplicated ARROW_LEFT/ARROW_RIGHT handlers; derived the reverse intensity/mode lookup maps from the forward maps; collapsed the configured-name if/else chain (7 calls to `getConfiguredNamePropertyName()` → 1); merged the duplicate `primaryAccessory`/`mainAccessory` fields into one parameter property
- **base + baseTv**: extracted `getOnMode()` (defaultOnMode/lastSyncMode fallback lived in 2 places) and `isSyncActive()` (`mode !== POWER_SAVE && mode !== PASSTHROUGH` lived in 4)
- **entertainmentTv**: replaced 3 manual 1-based counter loops with `Object.keys`/`Object.values` indexing, removing a `@ts-expect-error`
- **tv / intensityTv**: dropped redundant characteristic setup (duplicate `TargetVisibilityState` handler that `updateSources()` immediately overwrites; duplicate `SleepDiscoveryMode` set that the base constructor repeats)
- **client**: extracted `withLock()` — each public method now states only its request + error handling
- **platform**: merged the near-identical restore/register branches in `discoverDevices`; removed the double `mainAccessory` assignment; `Map.size` instead of `Array.from(values()).length`

## Deliberate judgment calls

- PLAY_PAUSE's lastSyncMode fallback unified from `?? MODE_VIDEO` to `|| MODE_VIDEO` (the variant `updateMode` already used); only differs for an empty-string `lastSyncMode`, where `||` is the safer of the two.
- `getOnMode()` drops the old `this?.state?.execution?.` optional chain. Every `State` reaching accessories passes `isValidState()` (which requires `execution` to be an object), and the surrounding code dereferences `this.state.execution` unguarded throughout — the chain was dead defensiveness (it even guarded `this`).
- Skipped: `handleConfigDefaults` loop-ification (would cost type-safety casts for marginal gain); `validation.ts`/`api-server.ts` (recent security work, already clean); adding `updateSources()` to entertainmentTv (would be a behavior change, not a simplification).

## Verification

- 91/91 unit tests pass unchanged after every commit
- `tsc --noEmit`, eslint, prettier, and `npm run build` clean
- Independent review pass over the full diff: no behavior deviations found beyond the documented calls above

https://claude.ai/code/session_01Cc6e7KS3W1jW989gRGMw27