### PR TITLE
chore(renovate): use the local> preset reference

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jabrown93/.github//renovate-config.json"],
+  "extends": ["local>jabrown93/.github:renovate-config"],
   "packageRules": [
     {
       "matchPackageNames": ["conventional-changelog-conventionalcommits"],


### PR DESCRIPTION
Part of a Renovate audit across all 17 owned repos. Independent — merge in any order.

Ten repos already write `local>jabrown93/.github:renovate-config`; seven, including this one, write `github>jabrown93/.github//renovate-config.json`. Both resolve to the same file (`renovate-config.json` at the root of `jabrown93/.github`), so this is purely a consistency change.

Standardizing on the shorter form means a search for the preset finds every consumer. `local>` also uses the configured platform rather than hardcoding GitHub, so a platform move would not need seventeen edits.

**No behavior change.** `renovate-config-validator` passes.

---
🤖 Authored by Claude (AI agent) at the repo owner's direction.

https://claude.ai/code/session_012gJxRyCGZLCG81R3jNvWes