### PR TITLE
refactor(renovate): extend the shared semantic-release preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>jabrown93/.github:renovate-config"],
-  "packageRules": [
-    {
-      "matchPackageNames": ["conventional-changelog-conventionalcommits"],
-      "allowedVersions": "<10.0.0",
-      "description": "Pinned to v9: v10 builds writerOpts from @conventional-changelog/template JS functions that require conventional-changelog-writer v9, but @semantic-release/release-notes-generator pins conventional-changelog-writer ^8 and silently ignores them, producing heading-only CHANGELOG entries with no commit bodies. Unpin once release-notes-generator supports writer v9."
-    }
+  "extends": [
+    "local>jabrown93/.github:renovate-config",
+    "local>jabrown93/.github:renovate-semantic-release"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jabrown93/.github//renovate-config.json"],
+  "extends": ["local>jabrown93/.github:renovate-config"],
   "packageRules": [
     {
       "matchPackageNames": ["conventional-changelog-conventionalcommits"],


### PR DESCRIPTION
Part of a Renovate audit across all 17 owned repos.

## ⚠️ Merge order

1. **jabrown93/.github#35** — adds the preset. Must merge first: Renovate resolves `local>` presets from the default branch of `jabrown93/.github`, and an unresolvable preset fails config resolution for this whole repo.
2. The `renovate-preset-ref` PR in this repo — this PR is **stacked on it** (base branch is `renovate-preset-ref`, not `main`). GitHub will retarget this to `main` automatically once that merges.
3. This PR.

## What

The `conventional-changelog-conventionalcommits <10.0.0` pin is copy-pasted verbatim into five repos: this one, the other three homebridge plugins, and `dev-config`. It is a workaround with a documented removal condition (`@semantic-release/release-notes-generator` supporting `conventional-changelog-writer` v9), so it belongs in one place rather than five — otherwise unpinning means remembering all five.

Replaced with `local>jabrown93/.github:renovate-semantic-release`, which carries the identical `matchPackageNames` / `allowedVersions` rule and the same explanation.

**No behavior change.** `renovate-config-validator` passes.

---
🤖 Authored by Claude (AI agent) at the repo owner's direction.

https://claude.ai/code/session_012gJxRyCGZLCG81R3jNvWes