### PR TITLE
ci(release): bump npm-release.yml to workflows-v1.1.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   release:
-    uses: jabrown93/ci/.github/workflows/npm-release.yml@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # workflows-v1.0.0
+    uses: jabrown93/ci/.github/workflows/npm-release.yml@de444474e2191350f3d6cd8c4af11da031890ae5 # workflows-v1.1.0
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Bumps the reusable `npm-release.yml` pin to `workflows-v1.1.0`, which stages the `jabrown93/ci/actions/release-commit` script (exports `RELEASE_COMMIT_SCRIPT`) before semantic-release — inert with the current `@jabrown93/dev-config` release config, **required** before the upcoming dev-config release (jabrown93/dev-config#16) reaches this repo via Renovate: that config creates the version-bump commit via the GitHub API (Verified) and fails loud if the variable is unset. Merge this ahead of that bump.

_PR opened by AI agent (Claude Code)._

https://claude.ai/code/session_01MVDfqm4AJGuGCXwkEftZL9