### PR TITLE
chore(renovate): keep runtime dependency ranges for this published plugin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,17 @@
   "extends": [
     "local>jabrown93/.github:renovate-config",
     "local>jabrown93/.github:renovate-semantic-release"
+  ],
+  "packageRules": [
+    {
+      "description": "This package is published to npm, so its runtime dependencies stay as ranges. The shared preset sets rangeStrategy=pin, which is correct for an application but wrong for a library: Homebridge installs every plugin into one shared node_modules, and an exact pin stops npm from deduping a dependency another plugin also uses -- two plugins pinning different axios versions each get their own copy. It also leaves a consumer no way to take a transitive patch without forking. devDependencies are still pinned via :pinDevDependencies, which is what makes our own builds reproducible; nothing here relaxes that.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "rangeStrategy": "replace"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,12 +7,8 @@
   "packageRules": [
     {
       "description": "This package is published to npm, so its runtime dependencies stay as ranges. The shared preset sets rangeStrategy=pin, which is correct for an application but wrong for a library: Homebridge installs every plugin into one shared node_modules, and an exact pin stops npm from deduping a dependency another plugin also uses -- two plugins pinning different axios versions each get their own copy. It also leaves a consumer no way to take a transitive patch without forking. devDependencies are still pinned via :pinDevDependencies, which is what makes our own builds reproducible; nothing here relaxes that.",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
       "rangeStrategy": "replace"
     }
   ]


### PR DESCRIPTION
Prep for a change to the shared preset (`jabrown93/.github:renovate-config`), which is switching `rangeStrategy` from `replace` to `pin` so every unpinned dependency across the org becomes exact.

That is the right default for an application, but wrong for a package published to npm. Homebridge installs every plugin into one shared `node_modules`; an exact pin in a plugin's `dependencies` stops npm from deduping a package another plugin also depends on, so two plugins pinning different `axios` versions each get their own copy. It also leaves a consumer no way to pick up a transitive security patch without forking.

This adds a repo-local `packageRule` keeping `rangeStrategy: replace` for npm `dependencies` only. `devDependencies` remain pinned via `:pinDevDependencies` — that is what makes our own builds reproducible, and nothing here relaxes it.

**Merge this before the preset change**, otherwise Renovate will open a pin PR against this plugin's runtime dependencies in the interim.

_Opened by an AI agent (Claude Code) on behalf of @jabrown93._

https://claude.ai/code/session_018NUCCZGRHchyh46qkg1dMV