### PR TITLE
chore: ignore Pi workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ web_modules/
 homebridge.log
 
 **/.worktrees
+.pi/


### PR DESCRIPTION
## Description

Ignore Pi's repository-local `.pi/` workspace so agent state does not appear as untracked content.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Other: repository tooling

## Checklist

- [x] My commits follow the Conventional Commits standard
- [ ] I have run the linter/formatter and test suite locally (not applicable: ignore-only change)
- [x] Tests added or updated where appropriate (not applicable: no runtime behavior)
- [x] Documentation updated where appropriate
- [x] This PR is focused and reasonably small to review