### PR TITLE
chore(release): promote beta to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.8-beta.2](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.8-beta.1...v3.0.8-beta.2) (2026-08-26)
+
+### Bug Fixes
+
+* **client:** retry Sync Box request timeouts instead of failing the poll ([#461](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/461)) ([3893a32](https://github.com/jabrown93/homebridge-philips-hue-sync-box/commit/3893a32a61ec90f4487d7cc13fa87dd240b8b29a)), closes [#458](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/458)
+
 ## [3.0.8-beta.1](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.7...v3.0.8-beta.1) (2026-07-18)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.8-beta.1](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.7...v3.0.8-beta.1) (2026-07-18)
+
+### Bug Fixes
+
+* **security:** pin Sync Box TLS to Philips's Sync Box CA ([#436](https://github.com/jabrown93/homebridge-philips-hue-sync-box/issues/436)) ([fd8c52f](https://github.com/jabrown93/homebridge-philips-hue-sync-box/commit/fd8c52fd3b8627eeb894725f4ed1cb0124ba222f))
+
 ## [3.0.7](https://github.com/jabrown93/homebridge-philips-hue-sync-box/compare/v3.0.6...v3.0.7) (2026-07-17)
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ npm run release                # Build and run semantic-release
   - Communicates with Philips Hue Sync Box HTTPS API
   - Uses async-lock to prevent concurrent requests
   - Includes retry logic (3 retries with exponential backoff)
-  - Accepts self-signed certificates (rejectUnauthorized: false)
+  - Pins TLS connections to Philips's Sync Box CA (`src/lib/hsb-ca-cert.ts`); hostname/CN verification is skipped since each box's cert CN is its device id, not its IP (see `createSyncBoxAgent()`)
   - Methods: `getState()`, `updateExecution()`, `updateHue()`
 
 ### State Management
@@ -154,7 +154,7 @@ Override `handlePowerCharacteristicSet()` or add new characteristic handlers. Al
 
 - This is an **ES2024 module** project - use `.js` extensions in import statements
 - The plugin uses **strict TypeScript** mode (except `noImplicitAny: false`)
-- Sync Box API uses **self-signed certificates** - certificate validation is disabled
+- Sync Box API uses **certificates signed by Philips's Sync Box CA** - the chain is validated but hostname verification is skipped (see `SyncBoxClient`)
 - API requests are **serialized** via async-lock to prevent conflicts
 - TV accessories are **external** and require manual HomeKit pairing
 - The platform uses **Homebridge's dynamic platform API** for accessory management

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-philips-hue-sync-box",
-  "version": "3.0.8-beta.1",
+  "version": "3.0.8-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-philips-hue-sync-box",
-      "version": "3.0.8-beta.1",
+      "version": "3.0.8-beta.2",
       "license": "MIT",
       "dependencies": {
         "async-lock": "^1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "async-lock": "^1.4.1",
-        "fetch-retry": "^6.0.0",
         "homebridge-lib": "^8.0.0",
         "node-fetch": "^3.3.2"
       },
@@ -6067,12 +6066,6 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
-    },
-    "node_modules/fetch-retry": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
-      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
-      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-philips-hue-sync-box",
-  "version": "3.0.7",
+  "version": "3.0.8-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-philips-hue-sync-box",
-      "version": "3.0.7",
+      "version": "3.0.8-beta.1",
       "license": "MIT",
       "dependencies": {
         "async-lock": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   "prettier": "@jabrown93/dev-config/prettier",
   "dependencies": {
     "async-lock": "^1.4.1",
-    "fetch-retry": "^6.0.0",
     "homebridge-lib": "^8.0.0",
     "node-fetch": "^3.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-philips-hue-sync-box",
   "displayName": "Philips Hue Sync Box",
-  "version": "3.0.7",
+  "version": "3.0.8-beta.1",
   "description": "Homebridge plugin for the Philips Hue Sync Box.",
   "keywords": [
     "homebridge-plugin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-philips-hue-sync-box",
   "displayName": "Philips Hue Sync Box",
-  "version": "3.0.8-beta.1",
+  "version": "3.0.8-beta.2",
   "description": "Homebridge plugin for the Philips Hue Sync Box.",
   "keywords": [
     "homebridge-plugin",

--- a/src/accessories/base.ts
+++ b/src/accessories/base.ts
@@ -102,10 +102,7 @@ export abstract class SyncBoxDevice {
     // Saves the changes
     if (newValue) {
       this.platform.log.debug('Switch state to ON');
-      mode = this.platform.config.defaultOnMode;
-      if (mode === MODE_LAST_SYNC) {
-        mode = this?.state?.execution?.lastSyncMode || MODE_VIDEO;
-      }
+      mode = this.getOnMode();
     } else {
       this.platform.log.debug('Switch state to OFF');
       mode = this.platform.config.defaultOffMode;
@@ -113,6 +110,16 @@ export abstract class SyncBoxDevice {
     return this.updateExecution({
       mode,
     });
+  }
+
+  // Resolves the configured default on-mode, falling back to video when
+  // 'lastSyncMode' is configured but the box has not synced yet.
+  protected getOnMode(): string {
+    const mode = this.platform.config.defaultOnMode;
+    if (mode !== MODE_LAST_SYNC) {
+      return mode;
+    }
+    return this.state.execution.lastSyncMode || MODE_VIDEO;
   }
 
   protected updateExecution(execution: Partial<Execution>) {
@@ -147,11 +154,17 @@ export abstract class SyncBoxDevice {
     );
   }
 
-  protected shouldBeOn(): boolean {
+  // True when the box is actively syncing (video/music/game), as opposed to
+  // sitting in passthrough or powersave.
+  protected isSyncActive(): boolean {
     return (
       this.state.execution.mode !== POWER_SAVE &&
       this.state.execution.mode !== PASSTHROUGH
     );
+  }
+
+  protected shouldBeOn(): boolean {
+    return this.isSyncActive();
   }
 
   protected getSuffix(): string {

--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -13,7 +13,6 @@ import {
   MODE_VIDEO,
   MODE_MUSIC,
   MODE_GAME,
-  MODE_LAST_SYNC,
   BRIGHTNESS_MAX_SYNCBOX,
   BRIGHTNESS_STEP_SYNCBOX,
   BRIGHTNESS_MIN,
@@ -23,8 +22,9 @@ import { convertSyncBoxToHomekit } from '../lib/brightness.js';
 export abstract class BaseTvDevice extends SyncBoxDevice {
   protected lightbulbService?: Service;
   protected inputServices: Service[] = [];
-  protected mainAccessory?: PlatformAccessory;
 
+  // The numbers double as HomeKit input identifiers, so the order is part of
+  // the accessory's UI. The reverse maps are derived to keep them in sync.
   protected readonly intensityToNumber: Map<string, number> = new Map([
     ['subtle', 1],
     ['moderate', 2],
@@ -32,12 +32,12 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     ['intense', 4],
   ]);
 
-  protected readonly numberToIntensity: Map<number, string> = new Map([
-    [1, 'subtle'],
-    [2, 'moderate'],
-    [3, 'high'],
-    [4, 'intense'],
-  ]);
+  protected readonly numberToIntensity: Map<number, string> = new Map(
+    [...this.intensityToNumber].map(([intensity, number]) => [
+      number,
+      intensity,
+    ])
+  );
 
   protected readonly modeToNumber: Map<string, number> = new Map([
     [MODE_VIDEO, 1],
@@ -47,22 +47,17 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     [POWER_SAVE, 5],
   ]);
 
-  protected readonly numberToMode: Map<number, string> = new Map([
-    [1, MODE_VIDEO],
-    [2, MODE_MUSIC],
-    [3, MODE_GAME],
-    [4, PASSTHROUGH],
-    [5, POWER_SAVE],
-  ]);
+  protected readonly numberToMode: Map<number, string> = new Map(
+    [...this.modeToNumber].map(([mode, number]) => [number, mode])
+  );
 
   protected constructor(
     protected readonly platform: HueSyncBoxPlatform,
     public readonly accessory: PlatformAccessory,
     protected state: State,
-    protected primaryAccessory?: PlatformAccessory
+    protected mainAccessory?: PlatformAccessory
   ) {
     super(platform, accessory, state);
-    this.mainAccessory = primaryAccessory;
 
     this.createInputServices();
     this.createLightbulbService();
@@ -75,16 +70,11 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
       .getCharacteristic(this.platform.api.hap.Characteristic.RemoteKey)
       .onSet(this.handleRemoteButton.bind(this));
 
-    let name;
-    if (this.platform.config[this.getConfiguredNamePropertyName()]) {
-      name = this.platform.config[this.getConfiguredNamePropertyName()];
-    } else if (
-      this.mainAccessory?.context[this.getConfiguredNamePropertyName()]
-    ) {
-      name = this.mainAccessory?.context[this.getConfiguredNamePropertyName()];
-    } else {
-      name = this.state.device.name;
-    }
+    const nameProperty = this.getConfiguredNamePropertyName();
+    const name =
+      this.platform.config[nameProperty] ||
+      this.mainAccessory?.context[nameProperty] ||
+      this.state.device.name;
     this.service
       .getCharacteristic(this.platform.api.hap.Characteristic.ConfiguredName)
       .onSet(this.handleConfiguredNameChange.bind(this));
@@ -95,20 +85,19 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
   }
 
   protected handleConfiguredNameChange(value: CharacteristicValue) {
-    if (this.platform.config[this.getConfiguredNamePropertyName()]) {
+    const nameProperty = this.getConfiguredNamePropertyName();
+    if (this.platform.config[nameProperty]) {
       this.platform.log.warn(
-        this.getConfiguredNamePropertyName() +
+        nameProperty +
           ' is set in the config, therefore it cannot be changed by HomeKit.' +
           ' Please change it in the Homebridge config. Alternatively remove the' +
           ' config and manually configure in HomeKit (not recommended).'
       );
       return;
     }
-    this.platform.log.debug(
-      this.getConfiguredNamePropertyName() + ' name changed to ' + value
-    );
+    this.platform.log.debug(nameProperty + ' name changed to ' + value);
     if (this.mainAccessory) {
-      this.mainAccessory.context[this.getConfiguredNamePropertyName()] = value;
+      this.mainAccessory.context[nameProperty] = value;
     }
   }
 
@@ -134,8 +123,6 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     this.lightbulbService =
       this.accessory.getService(this.platform.api.hap.Service.Lightbulb) ||
       this.accessory.addService(this.platform.api.hap.Service.Lightbulb);
-
-    // Stores the light bulb service
 
     // Subscribes for changes of the on characteristic
     this.lightbulbService
@@ -166,7 +153,6 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
   protected handleRemoteButton(value: CharacteristicValue) {
     this.platform.log.debug('Remote key pressed: ' + value);
 
-    let mode: string;
     switch (value) {
       case this.platform.api.hap.Characteristic.RemoteKey.ARROW_UP:
         this.platform.log.debug('Increase brightness by 25%');
@@ -188,57 +174,13 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
         });
         break;
 
-      case this.platform.api.hap.Characteristic.RemoteKey.ARROW_LEFT: {
-        // Gets the current mode or the last sync mode to set the intensity
-        mode = this.getMode();
-
-        this.platform.log.debug('Toggle intensity');
-        if (!this.state.execution[mode]) {
-          this.platform.log.debug(
-            'Current mode ' + mode + ' does not have an intensity to update'
-          );
-          break;
-        }
-        const currentIntensity = this.state.execution[mode].intensity;
-        const nextLowestIntensity =
-          (this.intensityToNumber.get(currentIntensity) ?? 4) - 1;
-        if (nextLowestIntensity < 1) {
-          break;
-        }
-        const nextIntensity = this.numberToIntensity.get(nextLowestIntensity);
-        const body = {};
-        body[mode] = {
-          intensity: nextIntensity,
-        };
-        this.updateExecution(body);
+      case this.platform.api.hap.Characteristic.RemoteKey.ARROW_LEFT:
+        this.stepIntensity(-1);
         break;
-      }
 
-      case this.platform.api.hap.Characteristic.RemoteKey.ARROW_RIGHT: {
-        // Gets the current mode or the last sync mode to set the intensity
-        mode = this.getMode();
-
-        this.platform.log.debug('Toggle intensity');
-        if (!this.state.execution[mode]) {
-          this.platform.log.debug(
-            'Current mode ' + mode + ' does not have an intensity to update'
-          );
-          break;
-        }
-        const currentIntensity = this.state.execution[mode].intensity;
-        const nextHighestIntensity =
-          (this.intensityToNumber.get(currentIntensity) ?? 1) + 1;
-        if (nextHighestIntensity > 4) {
-          break;
-        }
-        const nextIntensity = this.numberToIntensity.get(nextHighestIntensity);
-        const body = {};
-        body[mode] = {
-          intensity: nextIntensity,
-        };
-        this.updateExecution(body);
+      case this.platform.api.hap.Characteristic.RemoteKey.ARROW_RIGHT:
+        this.stepIntensity(1);
         break;
-      }
 
       case this.platform.api.hap.Characteristic.RemoteKey.SELECT: {
         this.platform.log.debug('Toggle mode');
@@ -252,21 +194,13 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
 
       case this.platform.api.hap.Characteristic.RemoteKey.PLAY_PAUSE:
         this.platform.log.debug('Toggle switch state');
-        if (
-          this.state.execution.mode !== POWER_SAVE &&
-          this.state.execution.mode !== PASSTHROUGH
-        ) {
+        if (this.isSyncActive()) {
           this.updateExecution({
             mode: this.platform.config.defaultOffMode,
           });
         } else {
-          let onMode: string = this.platform.config.defaultOnMode;
-          if (onMode === MODE_LAST_SYNC) {
-            onMode = this?.state?.execution?.lastSyncMode ?? MODE_VIDEO;
-          }
-
           this.updateExecution({
-            mode: onMode,
+            mode: this.getOnMode(),
           });
         }
         break;
@@ -282,6 +216,30 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
         break;
       }
     }
+  }
+
+  // An unknown current intensity falls back so the step still lands on a
+  // valid value: stepping down assumes 'intense' (4), stepping up 'subtle' (1).
+  private stepIntensity(direction: -1 | 1): void {
+    // Gets the current mode or the last sync mode to set the intensity
+    const mode = this.getMode();
+
+    this.platform.log.debug('Toggle intensity');
+    if (!this.state.execution[mode]) {
+      this.platform.log.debug(
+        'Current mode ' + mode + ' does not have an intensity to update'
+      );
+      return;
+    }
+    const currentIntensity = this.state.execution[mode].intensity;
+    const fallback = direction === -1 ? 4 : 1;
+    const nextIntensity = this.numberToIntensity.get(
+      (this.intensityToNumber.get(currentIntensity) ?? fallback) + direction
+    );
+    if (!nextIntensity) {
+      return;
+    }
+    this.updateExecution({ [mode]: { intensity: nextIntensity } });
   }
 
   protected updateSources(services: Service[]) {
@@ -314,8 +272,7 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     this.platform.log.debug('Updated state to ' + this.state.execution.mode);
     this.lightbulbService.updateCharacteristic(
       this.platform.api.hap.Characteristic.On,
-      this.state.execution.mode !== POWER_SAVE &&
-        this.state.execution.mode !== PASSTHROUGH
+      this.isSyncActive()
     );
     this.platform.log.debug(
       'Updated brightness to ' + this.state.execution.brightness
@@ -400,16 +357,10 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
   }
 
   protected getMode() {
-    let mode = MODE_VIDEO;
-    if (
-      this.state.execution.mode !== POWER_SAVE &&
-      this.state.execution.mode !== PASSTHROUGH
-    ) {
-      mode = this.state.execution.mode;
-    } else if (this.state.execution.lastSyncMode) {
-      mode = this.state.execution.lastSyncMode;
+    if (this.isSyncActive()) {
+      return this.state.execution.mode;
     }
-    return mode;
+    return this.state.execution.lastSyncMode || MODE_VIDEO;
   }
 
   protected abstract getConfiguredNamePropertyName(): string;

--- a/src/accessories/entertainmentTv.ts
+++ b/src/accessories/entertainmentTv.ts
@@ -14,20 +14,12 @@ export class EntertainmentTvDevice extends BaseTvDevice {
     this.service
       .getCharacteristic(this.platform.api.hap.Characteristic.ActiveIdentifier)
       .onSet(value => {
-        // Gets the ID of the group based on the index
-        let groupId: string | null = null;
-        let i = 1;
-        for (const currentGroupId in this.state.hue.groups) {
-          if (i === value) {
-            groupId = currentGroupId;
-            break;
-          }
-          i++;
-        }
-
-        // @ts-expect-error need to use self as a key
-        const group = this.state.hue.groups[groupId];
-        if (!group || !groupId) {
+        // The identifier is the group's 1-based position in the groups object
+        const groupId = Object.keys(this.state.hue.groups)[
+          (value as number) - 1
+        ];
+        const group = groupId ? this.state.hue.groups[groupId] : undefined;
+        if (!group) {
           return;
         }
         // Saves the changes
@@ -46,14 +38,11 @@ export class EntertainmentTvDevice extends BaseTvDevice {
   }
 
   updateTv(): void {
-    // Gets the ID of the group based on the index
-    let index = 1;
-    for (const currentGroupId in this.state.hue.groups) {
-      if (currentGroupId === this.state.hue.groupId) {
-        break;
-      }
-      index++;
-    }
+    // Gets the 1-based position of the active group; an unknown groupId
+    // falls past the last input, matching no source
+    const groupIds = Object.keys(this.state.hue.groups);
+    const position = groupIds.indexOf(this.state.hue.groupId);
+    const index = position === -1 ? groupIds.length + 1 : position + 1;
 
     // Updates the input characteristic
     this.service.updateCharacteristic(
@@ -83,19 +72,15 @@ export class EntertainmentTvDevice extends BaseTvDevice {
   }
 
   protected createInputServices(): void {
-    let i = 1;
-    for (const groupId in this.state.hue.groups) {
-      const group = this.state.hue.groups[groupId];
-      const name = group.name;
-      const position = 'AREA ' + i;
-
-      const entertainmentInputService = this.getInputService(name, position);
+    Object.values(this.state.hue.groups).forEach((group, index) => {
+      const entertainmentInputService = this.getInputService(
+        group.name,
+        'AREA ' + (index + 1)
+      );
 
       // Adds the input as a linked service, which is important so that the input is properly displayed in the Home app
       this.service.addLinkedService(entertainmentInputService);
       this.inputServices.push(entertainmentInputService);
-
-      i++;
-    }
+    });
   }
 }

--- a/src/accessories/intensityTv.ts
+++ b/src/accessories/intensityTv.ts
@@ -35,12 +35,6 @@ export class IntensityTvDevice extends BaseTvDevice {
       this.service.addLinkedService(intensityInputService);
       this.inputServices.push(intensityInputService);
     }
-    this.service.setCharacteristic(
-      this.platform.api.hap.Characteristic.SleepDiscoveryMode,
-      this.platform.api.hap.Characteristic.SleepDiscoveryMode
-        .ALWAYS_DISCOVERABLE
-    );
-
     this.updateSources(this.inputServices);
   }
 

--- a/src/accessories/tv.ts
+++ b/src/accessories/tv.ts
@@ -65,17 +65,11 @@ export class TvDevice extends BaseTvDevice {
   protected createInputServices(): void {
     const services: Service[] = [];
     for (let i = HDMI_INPUT_MIN; i <= HDMI_INPUT_MAX; i++) {
-      // Sets the TV name
       const hdmiState: HdmiInput = this.state.hdmi[`input${i}`];
       const hdmiPosition = 'HDMI ' + i;
 
       const hdmiName = hdmiState.name ?? hdmiPosition;
       const hdmiInputService = this.getInputService(hdmiName, hdmiPosition);
-      hdmiInputService
-        .getCharacteristic(
-          this.platform.api.hap.Characteristic.TargetVisibilityState
-        )
-        .onSet(this.setVisibility(hdmiInputService));
       // Adds the input as a linked service, which is important so that the input is properly displayed in the Home app
       this.service.addLinkedService(hdmiInputService);
       services.push(hdmiInputService);

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,5 +1,4 @@
-import originalFetch from 'node-fetch';
-import fetch_retry from 'fetch-retry';
+import fetch, { RequestInit } from 'node-fetch';
 
 import { Execution, Hue, State } from '../state.js';
 import * as https from 'node:https';
@@ -11,31 +10,12 @@ import {
   HTTP_RETRY_BASE_DELAY_MS,
   MAX_SYNC_BOX_RESPONSE_BYTES,
   SYNC_BOX_REQUEST_TIMEOUT_MS,
+  SYNC_BOX_REQUEST_BUDGET_MS,
   SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS,
   SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS,
 } from './constants.js';
 import { isValidState } from './validation.js';
 import { HSB_CA_CERT } from './hsb-ca-cert.js';
-
-const fetch = fetch_retry(originalFetch, {
-  retries: HTTP_RETRY_COUNT,
-  retryDelay: attempt => {
-    return Math.pow(2, attempt) * HTTP_RETRY_BASE_DELAY_MS; // 1000, 2000, 4000
-  },
-  // fetch-retry reuses the same request `init` - and so the same
-  // AbortSignal - across every retry attempt. Once our own request timeout
-  // fires, the signal is permanently aborted, so retrying just burns the
-  // full backoff delay on attempts that fail instantly for no benefit.
-  // Real network errors (connection refused/reset, DNS failure, etc.) still
-  // get retried normally.
-  //
-  // fetch-retry only enforces its own `retries` option when `retryOn` is an
-  // array; a function `retryOn` fully replaces that bound, so this has to
-  // check `attempt` itself or a persistent network error retries forever.
-  retryOn: (attempt: number, error: Error | null) => {
-    return !!error && error.name !== 'AbortError' && attempt < HTTP_RETRY_COUNT;
-  },
-});
 
 // Trusts only certs signed by Philips's Sync Box CA, but skips hostname
 // verification: each box's leaf cert has its uniqueId as the CN, not its IP,
@@ -49,6 +29,18 @@ export function createSyncBoxAgent(): https.Agent {
     checkServerIdentity: () => undefined,
     keepAlive: true,
   });
+}
+
+// The Sync Box answered, it just answered badly - a bad status or a payload
+// that isn't a state. Retrying only repeats the same answer, so these skip
+// the retry loop while transport failures don't.
+class SyncBoxResponseError extends Error {}
+
+// Homebridge prints a full stack when handed an Error. These failures all
+// unwind through node-fetch internals, so the stack costs a screen of log
+// and says nothing the message doesn't.
+function describeError(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
 }
 
 export class SyncBoxClient {
@@ -77,7 +69,9 @@ export class SyncBoxClient {
     try {
       return await this.withLock(() => this.sendRequest<State>('GET', ''));
     } catch (e) {
-      this.log.error('Failed to get state from Sync Box:', e);
+      // Polling retries on its own schedule, so a failed read is recoverable
+      // on the next tick rather than an error the user has to act on.
+      this.log.warn('Failed to get state from Sync Box:', describeError(e));
       return null;
     }
   }
@@ -88,7 +82,7 @@ export class SyncBoxClient {
         this.sendRequest<void>('PUT', 'execution', execution)
       );
     } catch (e) {
-      this.log.error('Error updating execution:', e);
+      this.log.error('Error updating execution:', describeError(e));
     }
   }
 
@@ -96,49 +90,37 @@ export class SyncBoxClient {
     try {
       await this.withLock(() => this.sendRequest<void>('PUT', 'hue', hue));
     } catch (e) {
-      this.log.error('Error updating hue:', e);
+      this.log.error('Error updating hue:', describeError(e));
     }
   }
 
-  private async sendRequest<T>(
+  /**
+   * Runs one attempt end to end - headers, status, body, validation - under a
+   * single AbortSignal, so a Sync Box that sends headers and then stalls
+   * mid-body aborts inside the retry loop rather than after it.
+   */
+  private async attemptRequest<T>(
+    url: string,
+    options: RequestInit,
     method: string,
-    path: string,
-    body?: Partial<Execution> | Partial<Hue> | null
+    deadline: number
   ): Promise<T> {
-    const url = `https://${this.config.syncBoxIpAddress}/api/v1/${path}`;
-    const options = {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.syncBoxApiAccessToken}`,
-      },
-      method,
-      body: body ? JSON.stringify(body) : null,
-      agent: this.agent,
-      // Aborts the response stream once it exceeds this many bytes, so a
-      // spoofed oversized response can't be fully buffered by res.json()
-      // before isValidState() gets a chance to reject it.
-      size: MAX_SYNC_BOX_RESPONSE_BYTES,
-      // Bounds the whole request (all retries included - see the retryOn
-      // override above) in case the Sync Box accepts the connection but
-      // never sends a response; node-fetch applies no timeout on its own.
-      signal: AbortSignal.timeout(SYNC_BOX_REQUEST_TIMEOUT_MS),
-    };
-
-    this.log.debug(
-      'Request to Sync Box:',
-      url,
-      JSON.stringify({
-        ...options,
-        headers: { ...options.headers, Authorization: '[REDACTED]' },
-      })
-    );
-
-    const res = await fetch(url, options);
+    const remaining = Math.max(deadline - Date.now(), 1);
+    const res = await fetch(url, {
+      ...options,
+      signal: AbortSignal.timeout(
+        Math.min(SYNC_BOX_REQUEST_TIMEOUT_MS, remaining)
+      ),
+    });
     if (!res.ok) {
+      // A stalled error body must not mask the status that explains it.
+      const detail = await res.text().catch(() => '<unreadable body>');
       this.log.error(
-        `Error: ${res.status} - ${res.statusText}. ${JSON.stringify(await res.json())}`
+        `Error: ${res.status} - ${res.statusText}. ${detail.slice(0, 500)}`
       );
-      throw new Error(`Error: ${res.status} - ${res.statusText}`);
+      throw new SyncBoxResponseError(
+        `Error: ${res.status} - ${res.statusText}`
+      );
     }
     if (method !== 'GET') {
       return null as T;
@@ -151,8 +133,69 @@ export class SyncBoxClient {
     // already crashed the entire Homebridge process, not just this plugin's
     // accessories.
     if (!isValidState(json)) {
-      throw new Error('Sync Box returned a malformed state response.');
+      throw new SyncBoxResponseError(
+        'Sync Box returned a malformed state response.'
+      );
     }
     return json as T;
+  }
+
+  /**
+   * Retries transport-level failures - this client's own request timeout
+   * included - under a single wall-clock budget.
+   *
+   * Every attempt gets a fresh AbortSignal. A shared signal stays aborted
+   * once it fires, so a Sync Box that answered a hair too slowly used to
+   * surface as an unretried AbortError even though the next poll succeeded.
+   */
+  private async sendRequest<T>(
+    method: string,
+    path: string,
+    body?: Partial<Execution> | Partial<Hue> | null
+  ): Promise<T> {
+    const url = `https://${this.config.syncBoxIpAddress}/api/v1/${path}`;
+    const options: RequestInit = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.config.syncBoxApiAccessToken}`,
+      },
+      method,
+      body: body ? JSON.stringify(body) : null,
+      agent: this.agent,
+      // Aborts the response stream once it exceeds this many bytes, so a
+      // spoofed oversized response can't be fully buffered by res.json()
+      // before isValidState() gets a chance to reject it.
+      size: MAX_SYNC_BOX_RESPONSE_BYTES,
+    };
+
+    this.log.debug(
+      'Request to Sync Box:',
+      url,
+      JSON.stringify({
+        ...options,
+        headers: { ...options.headers, Authorization: '[REDACTED]' },
+      })
+    );
+
+    const deadline = Date.now() + SYNC_BOX_REQUEST_BUDGET_MS;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await this.attemptRequest<T>(url, options, method, deadline);
+      } catch (e) {
+        const backoff = Math.pow(2, attempt) * HTTP_RETRY_BASE_DELAY_MS;
+        if (
+          e instanceof SyncBoxResponseError ||
+          attempt >= HTTP_RETRY_COUNT ||
+          Date.now() + backoff >= deadline
+        ) {
+          throw e;
+        }
+        this.log.debug(
+          `Sync Box request attempt ${attempt + 1} failed, retrying in ${backoff}ms:`,
+          e
+        );
+        await new Promise(resolve => setTimeout(resolve, backoff));
+      }
+    }
   }
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -68,41 +68,36 @@ export class SyncBoxClient {
     this.lock = new AsyncLock();
   }
 
+  // Serializes all Sync Box requests behind the shared lock.
+  private withLock<T>(task: () => Promise<T>): Promise<T> {
+    return this.lock.acquire(this.LOCK_KEY, task, this.LOCK_OPTIONS);
+  }
+
   public async getState(): Promise<State | null> {
-    return await this.lock
-      .acquire(
-        this.LOCK_KEY,
-        async () => await this.sendRequest<State>('GET', ''),
-        this.LOCK_OPTIONS
-      )
-      .catch(e => {
-        this.log.error('Failed to get state from Sync Box:', e);
-        return null;
-      });
+    try {
+      return await this.withLock(() => this.sendRequest<State>('GET', ''));
+    } catch (e) {
+      this.log.error('Failed to get state from Sync Box:', e);
+      return null;
+    }
   }
 
   public async updateExecution(execution: Partial<Execution>): Promise<void> {
-    return await this.lock
-      .acquire(
-        this.LOCK_KEY,
-        async () => await this.sendRequest<void>('PUT', 'execution', execution),
-        this.LOCK_OPTIONS
-      )
-      .catch(e => {
-        this.log.error('Error updating execution:', e);
-      });
+    try {
+      await this.withLock(() =>
+        this.sendRequest<void>('PUT', 'execution', execution)
+      );
+    } catch (e) {
+      this.log.error('Error updating execution:', e);
+    }
   }
 
   public async updateHue(hue: Partial<Hue>): Promise<void> {
-    return await this.lock
-      .acquire(
-        this.LOCK_KEY,
-        async () => await this.sendRequest<void>('PUT', 'hue', hue),
-        this.LOCK_OPTIONS
-      )
-      .catch(e => {
-        this.log.error('Error updating hue:', e);
-      });
+    try {
+      await this.withLock(() => this.sendRequest<void>('PUT', 'hue', hue));
+    } catch (e) {
+      this.log.error('Error updating hue:', e);
+    }
   }
 
   private async sendRequest<T>(

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -15,6 +15,7 @@ import {
   SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS,
 } from './constants.js';
 import { isValidState } from './validation.js';
+import { HSB_CA_CERT } from './hsb-ca-cert.js';
 
 const fetch = fetch_retry(originalFetch, {
   retries: HTTP_RETRY_COUNT,
@@ -36,6 +37,20 @@ const fetch = fetch_retry(originalFetch, {
   },
 });
 
+// Trusts only certs signed by Philips's Sync Box CA, but skips hostname
+// verification: each box's leaf cert has its uniqueId as the CN, not its IP,
+// and this plugin has no discovery step to learn that id ahead of connecting.
+// This still rejects arbitrary/self-signed certs from an untrusted LAN host -
+// it just can't distinguish this Sync Box's cert from another genuine one.
+export function createSyncBoxAgent(): https.Agent {
+  return new https.Agent({
+    ca: HSB_CA_CERT,
+    rejectUnauthorized: true,
+    checkServerIdentity: () => undefined,
+    keepAlive: true,
+  });
+}
+
 export class SyncBoxClient {
   private readonly LOCK_KEY = 'sync-box';
   private readonly LOCK_OPTIONS: AsyncLockOptions = {
@@ -44,10 +59,7 @@ export class SyncBoxClient {
   };
 
   private readonly lock: AsyncLock;
-  private readonly agent = new https.Agent({
-    rejectUnauthorized: false,
-    keepAlive: true,
-  });
+  private readonly agent = createSyncBoxAgent();
 
   constructor(
     private readonly log: Logger | Console,
@@ -137,11 +149,12 @@ export class SyncBoxClient {
       return null as T;
     }
     const json = await res.json();
-    // The Sync Box's cert is accepted without identity verification
-    // (rejectUnauthorized: false), so a LAN-adjacent attacker able to spoof
-    // its responses must not be able to hand every accessory's update() a
-    // shape it dereferences unconditionally - that already crashed the
-    // entire Homebridge process, not just this plugin's accessories.
+    // Any host with a cert signed by Philips's Sync Box CA is accepted
+    // regardless of hostname (see createSyncBoxAgent), so a LAN-adjacent
+    // attacker with a genuine Sync Box's cert must not be able to hand every
+    // accessory's update() a shape it dereferences unconditionally - that
+    // already crashed the entire Homebridge process, not just this plugin's
+    // accessories.
     if (!isValidState(json)) {
       throw new Error('Sync Box returned a malformed state response.');
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -87,8 +87,9 @@ export const MAX_API_BODY_BYTES = 100_000;
 export const API_REQUEST_TIMEOUT_MS = 10_000;
 
 // ===== Sync Box Client Security Constants =====
-// The Sync Box's cert is accepted without identity verification, so a
-// LAN-adjacent attacker able to spoof its address could otherwise return an
-// unbounded body and exhaust the shared Homebridge process's heap before
-// isValidState() ever runs. Legitimate state responses are a few KB.
+// Hostname isn't checked on the Sync Box's cert (see createSyncBoxAgent), so
+// a LAN-adjacent attacker with any cert signed by Philips's Sync Box CA could
+// otherwise return an unbounded body and exhaust the shared Homebridge
+// process's heap before isValidState() ever runs. Legitimate state responses
+// are a few KB.
 export const MAX_SYNC_BOX_RESPONSE_BYTES = 100_000;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -52,21 +52,31 @@ export const HTTP_STATUS_BAD_REQUEST = 400;
 export const HTTP_STATUS_PAYLOAD_TOO_LARGE = 413;
 export const HTTP_STATUS_METHOD_NOT_ALLOWED = 405;
 export const HTTP_STATUS_INTERNAL_ERROR = 500;
-// Aborts a single Sync Box request (all retries included, since fetch-retry
-// reuses the same AbortSignal) if it hangs with no response. Without this,
-// a connected-but-silent socket hangs node-fetch forever - no timeout of any
-// kind is applied by node-fetch v3 or fetch-retry on their own.
+// Aborts a single attempt if the Sync Box accepts the connection but never
+// sends a response. Each attempt gets its own signal, so a timed-out attempt
+// is retryable like any other network failure; node-fetch applies no timeout
+// of its own.
 export const SYNC_BOX_REQUEST_TIMEOUT_MS = 8000;
+// These three bound the same shared lock and must stay strictly ordered:
+//
+//   SYNC_BOX_REQUEST_TIMEOUT_MS  (one attempt)
+//     < SYNC_BOX_REQUEST_BUDGET_MS        (longest a caller can hold the lock)
+//     < SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS    (longest a caller waits for a turn)
+//     < SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS
+//
+// Ceiling on one sendRequest() call end to end - every attempt plus every
+// backoff. Without it, four 8s timeouts and 7s of backoff would run ~39s.
+// Above SYNC_BOX_REQUEST_TIMEOUT_MS so a timed-out attempt can still retry.
+export const SYNC_BOX_REQUEST_BUDGET_MS = 12000;
 // Queue-wait timeout for async-lock: how long a caller waits for a turn.
-export const SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS = 10000;
-// Worst case one sendRequest() call can take: SYNC_BOX_REQUEST_TIMEOUT_MS
-// for the first attempt, plus up to HTTP_RETRY_COUNT retries of real
-// (non-abort) network errors backing off at HTTP_RETRY_BASE_DELAY_MS *
-// 2^attempt each. Must stay comfortably above that worst case - if a job
-// legitimately runs longer than this, async-lock hands its slot to the next
-// queued caller while the original request keeps running in the background,
-// which can let two requests execute concurrently against the lock's
-// mutual-exclusion guarantee.
+// Below the budget, a HomeKit write queued behind a retrying poll expires
+// before it ever reaches the Sync Box - updateExecution() catches the
+// rejection and resolves, silently dropping the user's command.
+export const SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS = 15000;
+// If a job legitimately runs longer than this, async-lock hands its slot to
+// the next queued caller while the original request keeps running in the
+// background, which can let two requests execute concurrently against the
+// lock's mutual-exclusion guarantee.
 export const SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS = 20000;
 
 // ===== Intensity Constants =====

--- a/src/lib/hsb-ca-cert.ts
+++ b/src/lib/hsb-ca-cert.ts
@@ -1,0 +1,18 @@
+// Root CA that signs every Hue Sync Box's HTTPS leaf certificate. Shared across
+// all Sync Box devices (baked into the firmware) - it is not specific to any one
+// box, so it authenticates "a genuine Sync Box" rather than "this exact device".
+// Source: https://developers.meethue.com/wp-content/uploads/2020/01/hsb_cacert.pem_.txt
+// Documented at: https://developers.meethue.com/develop/hue-entertainment/hue-hdmi-sync-box-api/#HTTPS
+export const HSB_CA_CERT = `-----BEGIN CERTIFICATE-----
+MIIBwDCCAWagAwIBAgIBATAKBggqhkjOPQQDAjA2MQswCQYDVQQGEwJOTDEUMBIG
+A1UECgwLUGhpbGlwcyBIdWUxETAPBgNVBAMMCHJvb3QtaHNiMCAXDTE3MDEwMTAw
+MDAwMFoYDzk5OTkxMjMxMjM1OTU5WjA2MQswCQYDVQQGEwJOTDEUMBIGA1UECgwL
+UGhpbGlwcyBIdWUxETAPBgNVBAMMCHJvb3QtaHNiMFkwEwYHKoZIzj0CAQYIKoZI
+zj0DAQcDQgAEr9FgOxnsonsrnUZr3C4ggST7YCR9wISvDuwlNdZcAz4HiVCNmAAP
+tAnAFDG0U19Rmc4MfRYBMO8GrOHrOkZ7sKNjMGEwHQYDVR0OBBYEFCK+VIWZqp++
+DHqmGLWEZHYdH9v7MB8GA1UdIwQYMBaAFCK+VIWZqp++DHqmGLWEZHYdH9v7MA8G
+A1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49BAMCA0gAMEUC
+IAFDI0Q4IOPxV7cY4wSVOJAn4y5AdZwrItJ1XuNpmCltAiEA5c6wcu6qmF596uyA
+r7xLnr3/F5zJxrE3AyLD4t+5oKs=
+-----END CERTIFICATE-----
+`;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -261,7 +261,8 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
   async update(state: State | null) {
     this.log.debug('Updating state called');
     if (!state) {
-      this.log.warn('Could not get state from sync box. Skipping update.');
+      // getState() already logged why; don't warn twice per failed poll.
+      this.log.debug('No state from sync box. Skipping update.');
       return;
     }
     for (const device of this.devices) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -177,27 +177,31 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
     this.log.debug('Discovered state:', this.redactStateForLogging(state));
     const accessories = this.discoverAccessories(state);
     const uuids = accessories.map(accessory => {
-      const uuid = accessory.UUID; // see if an accessory with the same uuid has already been registered and restored from
+      const uuid = accessory.UUID;
+      // see if an accessory with the same uuid has already been registered
+      // and restored from cache
       const existingAccessory = this.existingAccessories.get(uuid);
-      const isMainAccessory = accessory.UUID === this.mainAccessory?.UUID;
-      const isPowerSwitch = accessory.context.kind === POWER_SWITCH_ACCESSORY;
+      const target = existingAccessory ?? accessory;
       if (existingAccessory) {
         this.log.debug(
           'Restoring existing accessory from cache: ',
           existingAccessory.context.kind
         );
-        const device = this.createDevice(existingAccessory, state);
-        this.accessories.set(accessory.UUID, existingAccessory);
-        this.devices.push(device);
-        if (isMainAccessory || isPowerSwitch) {
-          this.api.updatePlatformAccessories([existingAccessory]);
-        }
       } else {
         this.log.info('Registering new accessory:', accessory.context.kind);
-        const device = this.createDevice(accessory, state);
-        this.devices.push(device);
-        this.accessories.set(accessory.UUID, accessory);
-        if (isMainAccessory || isPowerSwitch) {
+      }
+      this.devices.push(this.createDevice(target, state));
+      this.accessories.set(uuid, target);
+
+      // Only the main and power switch accessories are bridged; TVs are
+      // published separately as external accessories.
+      const isBridged =
+        uuid === this.mainAccessory?.UUID ||
+        accessory.context.kind === POWER_SWITCH_ACCESSORY;
+      if (isBridged) {
+        if (existingAccessory) {
+          this.api.updatePlatformAccessories([existingAccessory]);
+        } else {
           this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
             accessory,
           ]);
@@ -219,7 +223,7 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
     });
 
     this.log.debug(
-      `Publishing external ${Array.from(this.externalAccessories.values()).length} accessories`
+      `Publishing external ${this.externalAccessories.size} accessories`
     );
     this.api.publishExternalAccessories(
       PLUGIN_NAME,
@@ -343,12 +347,8 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
       this.api.hap.uuid.generate(kind + uuidSeed)
     );
     if (kind === LIGHTBULB_ACCESSORY) {
-      this.mainAccessory = accessory;
       accessory.category = this.api.hap.Categories.LIGHTBULB;
-    } else if (kind === SWITCH_ACCESSORY) {
-      this.mainAccessory = accessory;
-      accessory.category = this.api.hap.Categories.SWITCH;
-    } else if (kind === POWER_SWITCH_ACCESSORY) {
+    } else if (kind === SWITCH_ACCESSORY || kind === POWER_SWITCH_ACCESSORY) {
       accessory.category = this.api.hap.Categories.SWITCH;
     }
     accessory.context.kind = kind;

--- a/test/unit/lib/client.test.ts
+++ b/test/unit/lib/client.test.ts
@@ -7,17 +7,20 @@ import { HSB_CA_CERT } from '../../../src/lib/hsb-ca-cert.js';
 // vi.hoisted to avoid a temporal-dead-zone reference inside the factory.
 const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
 
-// SyncBoxClient imports node-fetch as its default export and wraps it with
-// fetch-retry at module load time, so the mock has to be installed before
-// src/lib/client.js (and transitively node-fetch) is ever imported.
+// SyncBoxClient imports node-fetch as its default export at module load
+// time, so the mock has to be installed before src/lib/client.js (and
+// transitively node-fetch) is ever imported.
 vi.mock('node-fetch', () => ({
   default: mockFetch,
 }));
 
 const { SyncBoxClient, createSyncBoxAgent } =
   await import('../../../src/lib/client.js');
-const { HTTP_RETRY_BASE_DELAY_MS, MAX_SYNC_BOX_RESPONSE_BYTES } =
-  await import('../../../src/lib/constants.js');
+const {
+  HTTP_RETRY_BASE_DELAY_MS,
+  MAX_SYNC_BOX_RESPONSE_BYTES,
+  SYNC_BOX_REQUEST_TIMEOUT_MS,
+} = await import('../../../src/lib/constants.js');
 
 function makeLog() {
   return {
@@ -73,8 +76,14 @@ function errorResponse(status: number, statusText: string, body: unknown) {
     ok: false,
     status,
     statusText,
-    json: async () => body,
+    text: async () => JSON.stringify(body),
   };
+}
+
+function abortError() {
+  const e = new Error('The operation was aborted.');
+  e.name = 'AbortError';
+  return e;
 }
 
 describe('SyncBoxClient', () => {
@@ -108,21 +117,112 @@ describe('SyncBoxClient', () => {
     expect(secondOptions.signal).not.toBe(firstOptions.signal);
   });
 
-  it('does not retry once its own request timeout aborts the request', async () => {
-    const abortError = new Error('The operation was aborted.');
-    abortError.name = 'AbortError';
-    mockFetch.mockRejectedValue(abortError);
-    const log = makeLog();
-    const client = new SyncBoxClient(log, makeConfig());
+  // Regression test for #458: a Sync Box that answers a hair too slowly used
+  // to abort with no retry, because fetch-retry reused one already-aborted
+  // signal across every attempt.
+  it('retries after its own request timeout aborts an attempt', async () => {
+    vi.useFakeTimers();
+    try {
+      const validState = makeValidState();
+      mockFetch
+        .mockRejectedValueOnce(abortError())
+        .mockResolvedValueOnce(okResponse(validState));
+      const log = makeLog();
+      const client = new SyncBoxClient(log, makeConfig());
 
-    const result = await client.getState();
+      const resultPromise = client.getState();
+      await vi.advanceTimersByTimeAsync(HTTP_RETRY_BASE_DELAY_MS);
+      const result = await resultPromise;
 
-    expect(result).toBeNull();
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(log.error).toHaveBeenCalledWith(
-      'Failed to get state from Sync Box:',
-      abortError
-    );
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(validState);
+      expect(log.warn).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('gives every attempt a fresh, un-aborted signal', async () => {
+    vi.useFakeTimers();
+    try {
+      mockFetch
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce(okResponse(makeValidState()));
+      const client = new SyncBoxClient(makeLog(), makeConfig());
+
+      const resultPromise = client.getState();
+      await vi.advanceTimersByTimeAsync(HTTP_RETRY_BASE_DELAY_MS);
+      await resultPromise;
+
+      const signals = mockFetch.mock.calls.map(
+        ([, options]) => (options as { signal: AbortSignal }).signal
+      );
+      expect(signals[1]).not.toBe(signals[0]);
+      expect(signals[1].aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The retry loop used to return as soon as headers arrived, leaving
+  // res.json() to reject outside it. A Sync Box that sent headers and then
+  // stalled mid-body still failed the poll outright.
+  it('retries when the response body stalls after headers arrive', async () => {
+    vi.useFakeTimers();
+    try {
+      const validState = makeValidState();
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => {
+            throw abortError();
+          },
+        })
+        .mockResolvedValueOnce(okResponse(validState));
+      const log = makeLog();
+      const client = new SyncBoxClient(log, makeConfig());
+
+      const resultPromise = client.getState();
+      await vi.advanceTimersByTimeAsync(HTTP_RETRY_BASE_DELAY_MS);
+      const result = await resultPromise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(validState);
+      expect(log.warn).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops retrying once the wall-clock request budget is spent', async () => {
+    vi.useFakeTimers();
+    try {
+      // AbortSignal.timeout isn't driven by fake timers, so each attempt
+      // simulates burning its full timeout by pushing the clock forward -
+      // that's what the deadline is measured against. The budget, not
+      // HTTP_RETRY_COUNT, is then what ends the loop.
+      mockFetch.mockImplementation(async () => {
+        vi.setSystemTime(Date.now() + SYNC_BOX_REQUEST_TIMEOUT_MS);
+        throw abortError();
+      });
+      const log = makeLog();
+      const client = new SyncBoxClient(log, makeConfig());
+
+      const resultPromise = client.getState();
+      await vi.advanceTimersByTimeAsync(HTTP_RETRY_BASE_DELAY_MS * 4);
+      const result = await resultPromise;
+
+      expect(result).toBeNull();
+      expect(mockFetch.mock.calls.length).toBeLessThan(4);
+      expect(log.warn).toHaveBeenCalledWith(
+        'Failed to get state from Sync Box:',
+        'The operation was aborted.'
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('retries a real network error and succeeds once the retry resolves', async () => {
@@ -136,13 +236,13 @@ describe('SyncBoxClient', () => {
       const client = new SyncBoxClient(log, makeConfig());
 
       const resultPromise = client.getState();
-      // fetch-retry's first backoff delay is 2^0 * HTTP_RETRY_BASE_DELAY_MS.
+      // First backoff is 2^0 * HTTP_RETRY_BASE_DELAY_MS.
       await vi.advanceTimersByTimeAsync(HTTP_RETRY_BASE_DELAY_MS);
       const result = await resultPromise;
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(result).not.toBeNull();
-      expect(log.error).not.toHaveBeenCalled();
+      expect(log.warn).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -167,7 +267,7 @@ describe('SyncBoxClient', () => {
     }
   }, 3000);
 
-  it('does not retry an HTTP error status and logs then returns null', async () => {
+  it('does not retry an HTTP error status - the box answered, it just answered badly', async () => {
     mockFetch.mockResolvedValue(
       errorResponse(500, 'Internal Server Error', { error: 'boom' })
     );
@@ -178,13 +278,13 @@ describe('SyncBoxClient', () => {
 
     expect(result).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(log.error).toHaveBeenCalledWith(
+    expect(log.warn).toHaveBeenCalledWith(
       'Failed to get state from Sync Box:',
-      expect.any(Error)
+      'Error: 500 - Internal Server Error'
     );
   });
 
-  it('rejects a malformed state response instead of forwarding it', async () => {
+  it('rejects a malformed state response without retrying it', async () => {
     mockFetch.mockResolvedValue(okResponse({ not: 'a valid state' }));
     const log = makeLog();
     const client = new SyncBoxClient(log, makeConfig());
@@ -193,11 +293,9 @@ describe('SyncBoxClient', () => {
 
     expect(result).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(log.error).toHaveBeenCalledWith(
+    expect(log.warn).toHaveBeenCalledWith(
       'Failed to get state from Sync Box:',
-      expect.objectContaining({
-        message: 'Sync Box returned a malformed state response.',
-      })
+      'Sync Box returned a malformed state response.'
     );
   });
 

--- a/test/unit/lib/client.test.ts
+++ b/test/unit/lib/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { HueSyncBoxPlatformConfig } from '../../../src/config.js';
 import type { State } from '../../../src/state.js';
+import { HSB_CA_CERT } from '../../../src/lib/hsb-ca-cert.js';
 
 // vi.mock is hoisted above these imports, so the mock fetch fn must come from
 // vi.hoisted to avoid a temporal-dead-zone reference inside the factory.
@@ -13,7 +14,8 @@ vi.mock('node-fetch', () => ({
   default: mockFetch,
 }));
 
-const { SyncBoxClient } = await import('../../../src/lib/client.js');
+const { SyncBoxClient, createSyncBoxAgent } =
+  await import('../../../src/lib/client.js');
 const { HTTP_RETRY_BASE_DELAY_MS, MAX_SYNC_BOX_RESPONSE_BYTES } =
   await import('../../../src/lib/constants.js');
 
@@ -207,5 +209,23 @@ describe('SyncBoxClient', () => {
     const result = await client.getState();
 
     expect(result).toEqual(validState);
+  });
+});
+
+describe('createSyncBoxAgent', () => {
+  it('pins to the Sync Box CA and requires the chain to validate', () => {
+    const agent = createSyncBoxAgent();
+    expect(agent.options.ca).toBe(HSB_CA_CERT);
+    expect(agent.options.rejectUnauthorized).toBe(true);
+  });
+
+  it('skips hostname verification since leaf certs are keyed by device id, not IP', () => {
+    const agent = createSyncBoxAgent();
+    const checkServerIdentity = agent.options
+      .checkServerIdentity as unknown as (
+      hostname: string,
+      cert: unknown
+    ) => Error | undefined;
+    expect(checkServerIdentity('192.168.1.50', {} as never)).toBeUndefined();
   });
 });

--- a/test/unit/lib/constants.test.ts
+++ b/test/unit/lib/constants.test.ts
@@ -26,6 +26,8 @@ import {
   HTTP_STATUS_OK,
   HTTP_STATUS_UNAUTHORIZED,
   SYNC_BOX_REQUEST_TIMEOUT_MS,
+  SYNC_BOX_REQUEST_BUDGET_MS,
+  SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS,
   SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS,
 } from '../../../src/lib/constants.js';
 
@@ -131,21 +133,31 @@ describe('Constants', () => {
   });
 
   describe('Sync Box Client Timing Constants', () => {
-    it('should keep the lock max execution time comfortably above the worst-case request time', () => {
-      // Mirrors sendRequest()'s actual worst case: the bounded first
-      // attempt, plus every retry backing off at HTTP_RETRY_BASE_DELAY_MS *
-      // 2^attempt. If this ever regresses, async-lock can hand a request's
-      // slot to the next queued caller while the original is still running,
-      // letting two requests execute concurrently.
-      let worstCaseRetryDelay = 0;
-      for (let attempt = 0; attempt < HTTP_RETRY_COUNT; attempt++) {
-        worstCaseRetryDelay += Math.pow(2, attempt) * HTTP_RETRY_BASE_DELAY_MS;
-      }
-      const worstCaseRequestTime =
-        SYNC_BOX_REQUEST_TIMEOUT_MS + worstCaseRetryDelay;
+    // Every one of these bounds the same shared lock, and each inversion has
+    // its own failure mode:
+    //
+    // - budget <= attempt timeout: a timeout is terminal again (#458).
+    // - queue timeout <= budget: a HomeKit write queued behind a retrying
+    //   poll expires before its turn, and updateExecution() catches the
+    //   rejection and resolves - silently dropping the user's command.
+    // - lock max execution <= queue timeout: async-lock hands a slot to the
+    //   next caller while the original request is still in flight, so two
+    //   requests run concurrently.
+    it('should keep the lock timing constants strictly ordered', () => {
+      expect(SYNC_BOX_REQUEST_TIMEOUT_MS).toBeLessThan(
+        SYNC_BOX_REQUEST_BUDGET_MS
+      );
+      expect(SYNC_BOX_REQUEST_BUDGET_MS).toBeLessThan(
+        SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS
+      );
+      expect(SYNC_BOX_LOCK_QUEUE_TIMEOUT_MS).toBeLessThan(
+        SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS
+      );
+    });
 
-      expect(SYNC_BOX_LOCK_MAX_EXECUTION_TIME_MS).toBeGreaterThan(
-        worstCaseRequestTime
+    it('should leave the budget room for at least one retry after a timeout', () => {
+      expect(SYNC_BOX_REQUEST_BUDGET_MS).toBeGreaterThan(
+        SYNC_BOX_REQUEST_TIMEOUT_MS + HTTP_RETRY_BASE_DELAY_MS
       );
     });
   });

--- a/test/unit/lib/hsb-ca-cert.test.ts
+++ b/test/unit/lib/hsb-ca-cert.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { X509Certificate } from 'node:crypto';
+import { HSB_CA_CERT } from '../../../src/lib/hsb-ca-cert.js';
+
+describe('HSB_CA_CERT', () => {
+  it('parses as a valid, self-signed X.509 certificate', () => {
+    const cert = new X509Certificate(HSB_CA_CERT);
+    expect(cert.issuer).toBe(cert.subject);
+    expect(cert.checkIssued(cert)).toBe(true);
+  });
+
+  it('identifies Philips Hue as the issuer of the Sync Box root CA', () => {
+    const cert = new X509Certificate(HSB_CA_CERT);
+    expect(cert.subject).toContain('O=Philips Hue');
+    expect(cert.subject).toContain('CN=root-hsb');
+  });
+
+  it('is marked as a CA certificate', () => {
+    const cert = new X509Certificate(HSB_CA_CERT);
+    expect(cert.ca).toBe(true);
+  });
+
+  it('is currently valid', () => {
+    const cert = new X509Certificate(HSB_CA_CERT);
+    const now = Date.now();
+    expect(new Date(cert.validFrom).getTime()).toBeLessThan(now);
+    expect(new Date(cert.validTo).getTime()).toBeGreaterThan(now);
+  });
+});


### PR DESCRIPTION
Promotes the `3.0.8-beta` line to the release channel.

## Changes coming from `beta`

- `fix(security)`: pin Sync Box TLS to Philips's Sync Box CA (#436)
- `refactor`: simplify accessories, client, and platform (#451)
- `fix(client)`: retry Sync Box request timeouts instead of failing the poll (#461) closes #458

## Conflict resolution

Only release metadata conflicted (`CHANGELOG.md`, `package.json`, `package-lock.json`) — no source conflicts. `main`'s side was taken for all three: semantic-release owns the version fields, and `main` carries the newer devDependencies plus the `types` field and `git+https` repository URL that `beta` predates. The `3.0.8-beta.x` CHANGELOG sections are dropped; those fixes will appear under the new release entry.

`fetch-retry` is removed from `dependencies`. #461 replaced it with the client's own retry loop, so it had no remaining runtime usage.

## Verification

`npm ci`, `tsc --noEmit`, `eslint`, `prettier --check`, `vitest run` — all pass locally (95/95 tests).

## Merge method

**Merge with a merge commit, not squash.** semantic-release needs the individual `fix(...)` commits to generate the changelog and compute the bump; squashing would collapse them into one entry and leave `beta` diverged from `main`. Merge commits are being enabled on the repo for this PR and disabled again afterwards.

Expected release: **3.1.2** (patch — two `fix` commits).