### PR TITLE
ci: restore licence scanning with FOSSA

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,0 +1,45 @@
+---
+# FOSSA licence and dependency scan.
+#
+# Restores the advisory licence check this repo lost when the homelab
+# Dependency-Track instance was decommissioned (jabrown93/homelab#3167). DT's
+# policy engine held that role; FOSSA takes it back.
+#
+# Push-only, and never `pull_request`. FOSSA_API_KEY is a write-scoped push
+# token that identifies and updates the FOSSA project, so it must not be
+# exposed to PR-controlled code -- and a fork PR would not receive it anyway.
+# The practical cost is that the scan is now post-merge rather than pre-merge;
+# it was always advisory, so there is no gate being lost.
+#
+# main only: this answers "what licences ship", and the prerelease branches
+# would only add transient revisions to the same FOSSA project.
+name: FOSSA
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: fossa-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Licence scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # run-tests stays off: the scan is advisory, and `fossa test` blocks on
+      # FOSSA finishing its server-side analysis.
+      - name: FOSSA scan
+        uses: jabrown93/ci/actions/fossa@27a3e412cf691a8d106bfb429584e8f8aebb2406 # fossa-v1.0.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Follow-up to the DT-removal PR in this repo, which deleted `dt-sbom.yml`, `pr-license-check.yml` and `pr-license-comment.yml` and left licence scanning dark. This restores it via FOSSA, the role it held before Dependency-Track took over.

Uses the shared `fossa` composite action released by jabrown93/ci#78 (`fossa-v1.0.0`) — one `fossas/fossa-action` pin to bump for all four homebridge repos instead of four.

## Decisions

- **`push` on `main` only, never `pull_request`.** `FOSSA_API_KEY` is a write-scoped *push* token: it identifies and updates the FOSSA project. Exposing it to PR-controlled code is the thing to avoid, and a fork PR would not receive it regardless. The cost is that the check moves from pre-merge to post-merge — it was always advisory, so no gate is lost.
- **`run-tests` left off** (the action's default). `fossa test` would fail the job on a policy violation and blocks on FOSSA's server-side scan completing. Advisory matches what the DT policy engine did (WARN/INFO, non-gating).
- **`main` only, not the prerelease branches.** This answers "what licences ship"; `beta`/`alpha`/`next` would only add transient revisions to the same FOSSA project.
- `workflow_dispatch` so a scan can be forced without an empty commit.

## Precondition

`FOSSA_API_KEY` is pushed to this repo's Actions secrets by ESO from OpenBao — see jabrown93/homelab#3170. Already in place for this repo.

`ci:` type, so semantic-release will not cut a version for it.
