### PR TITLE
ci: attach SBOMs to npm releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   release:
-    uses: jabrown93/ci/.github/workflows/npm-release.yml@28ec69f555a61dd8770c3814b157ef2c50f1f8d5 # workflows-v2.0.0
+    uses: jabrown93/ci/.github/workflows/npm-release.yml@961ef8052b3fe4906b0245c190639af19ed2073b # workflows-v2.1.0
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/sbom-release.yml
+++ b/.github/workflows/sbom-release.yml
@@ -1,0 +1,14 @@
+---
+name: SBOM release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sbom:
+    uses: jabrown93/ci/.github/workflows/sbom-release.yml@961ef8052b3fe4906b0245c190639af19ed2073b # workflows-v2.1.0
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write


### PR DESCRIPTION
## Summary

- add the `release: published` caller for `jabrown93/ci`'s npm SBOM workflow
- upload CycloneDX and SPDX SBOMs plus the packed tarball as release assets
- attest both SBOM formats to the tarball
- align the existing reusable workflow pin with `workflows-v2.1.0`

This closes the npm release-artifact gap left by retiring Dependency-Track. FOSSA remains the advisory licence scanner.

## Security

- reusable workflow pinned to a full commit SHA
- release-only trigger; no PR-controlled code path
- caller grants only required `contents`, `id-token`, and `attestations` permissions

## Verification

- `actionlint .github/workflows/*.y*ml`
- `git diff --check`
- YAML/LSP diagnostics: 0 findings

Application tests not run: workflow-only change.
