### PR TITLE
ci: merge main back into beta after every push

### DIFF
--- a/.github/workflows/merge-back.yaml
+++ b/.github/workflows/merge-back.yaml
@@ -1,0 +1,28 @@
+# Merge main back into the prerelease branches after every push to main, so
+# beta never falls behind the stable line — semantic-release otherwise computes
+# beta's next prerelease version from a stale base. Branches the repo does not
+# have are skipped by the action, so the default branch list needs no tuning.
+#
+# This fires a second time on the version-bump commit semantic-release pushes to
+# main: that push is authenticated as the App, and App-token pushes do trigger
+# workflows. beta therefore converges on the release commit too, with no
+# schedule trigger needed.
+name: Merge back
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+concurrency:
+  group: merge-back-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  merge-back:
+    runs-on: ubuntu-latest
+    # No GITHUB_TOKEN permissions are needed: the action authenticates as the
+    # release App, which is the only identity that bypasses beta's rulesets.
+    permissions: {}
+    steps:
+      - uses: jabrown93/ci/actions/merge-back@fb273aa5f814f837727167724c752a4ff1254172 # merge-back-v1.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
`beta` is **73 commits behind `main`** and has no way to catch up on its own, so semantic-release computes its next prerelease version from a stale base.

Adds the shared [`merge-back`](https://github.com/jabrown93/ci/tree/main/actions/merge-back) action, which merges `main` into `beta` after every push to `main` via the GitHub merges API — the only route `beta`'s rulesets leave open:

| Rule | Blocks |
| --- | --- |
| `required_signatures` | a runner-side git merge commit — unsigned, rejected |
| `require-pull-request` + squash-only | squashing `main` into `beta` rewrites history, so every later merge-back conflicts |

The release App is a bypass actor on both, and the API merge commit is signed by GitHub. `201` merged / `204` already current / `409` opens a PR and leaves the run green. Branches this repo does not have are skipped, so no per-repo tuning.

First run merges the 73-commit backlog; `beta` is 0 commits ahead of `main`, so it is conflict-free.