### PR TITLE
feat: surface Sync Box failures instead of reporting success

### DIFF
--- a/src/accessories/base.ts
+++ b/src/accessories/base.ts
@@ -15,6 +15,7 @@ import {
   MODE_VIDEO,
 } from '../lib/constants.js';
 import { convertHomekitToSyncBox } from '../lib/brightness.js';
+import { describeError } from '../lib/client.js';
 
 export abstract class SyncBoxDevice {
   protected readonly platform: HueSyncBoxPlatform;
@@ -122,15 +123,21 @@ export abstract class SyncBoxDevice {
     return this.state.execution.lastSyncMode || MODE_VIDEO;
   }
 
-  protected updateExecution(execution: Partial<Execution>) {
-    this.platform.client.updateExecution(execution).catch(e => {
-      this.platform.log.error('Failed to update execution', e);
+  // Rejects so the onSet handler that called it rejects too: HomeKit then
+  // shows the command as failed instead of reporting a state the Sync Box
+  // never accepted.
+  protected updateExecution(execution: Partial<Execution>): Promise<void> {
+    return this.platform.client.updateExecution(execution).catch(e => {
+      this.platform.log.error('Failed to update execution:', describeError(e));
+      throw new this.platform.api.hap.HapStatusError(
+        HAPStatus.SERVICE_COMMUNICATION_FAILURE
+      );
     });
   }
 
   protected setBrightness(value: CharacteristicValue) {
     this.platform.log.debug('Switch brightness to ' + value);
-    this.updateExecution({
+    return this.updateExecution({
       brightness: convertHomekitToSyncBox(value as number),
     });
   }

--- a/src/accessories/baseTv.ts
+++ b/src/accessories/baseTv.ts
@@ -156,71 +156,60 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     switch (value) {
       case this.platform.api.hap.Characteristic.RemoteKey.ARROW_UP:
         this.platform.log.debug('Increase brightness by 25%');
-        this.updateExecution({
+        return this.updateExecution({
           brightness: Math.min(
             BRIGHTNESS_MAX_SYNCBOX,
             this.state.execution.brightness + BRIGHTNESS_STEP_SYNCBOX
           ),
         });
-        break;
 
       case this.platform.api.hap.Characteristic.RemoteKey.ARROW_DOWN:
         this.platform.log.debug('Decrease brightness by 25%');
-        this.updateExecution({
+        return this.updateExecution({
           brightness: Math.max(
             BRIGHTNESS_MIN,
             this.state.execution.brightness - BRIGHTNESS_STEP_SYNCBOX
           ),
         });
-        break;
 
       case this.platform.api.hap.Characteristic.RemoteKey.ARROW_LEFT:
-        this.stepIntensity(-1);
-        break;
+        return this.stepIntensity(-1);
 
       case this.platform.api.hap.Characteristic.RemoteKey.ARROW_RIGHT:
-        this.stepIntensity(1);
-        break;
+        return this.stepIntensity(1);
 
       case this.platform.api.hap.Characteristic.RemoteKey.SELECT: {
         this.platform.log.debug('Toggle mode');
         const currentMode = this.state.execution.mode;
         const nextMode = ((this.modeToNumber.get(currentMode) ?? 4) % 4) + 1;
-        this.updateExecution({
+        return this.updateExecution({
           mode: this.numberToMode.get(nextMode),
         });
-        break;
       }
 
       case this.platform.api.hap.Characteristic.RemoteKey.PLAY_PAUSE:
         this.platform.log.debug('Toggle switch state');
-        if (this.isSyncActive()) {
-          this.updateExecution({
-            mode: this.platform.config.defaultOffMode,
-          });
-        } else {
-          this.updateExecution({
-            mode: this.getOnMode(),
-          });
-        }
-        break;
+        return this.updateExecution({
+          mode: this.isSyncActive()
+            ? this.platform.config.defaultOffMode
+            : this.getOnMode(),
+        });
 
       case this.platform.api.hap.Characteristic.RemoteKey.INFORMATION: {
         this.platform.log.debug('Toggle hdmi source');
         const hdmiSource = this.state.execution.hdmiSource;
         const currentSourcePosition = parseInt(hdmiSource.replace('input', ''));
         const nextSourcePosition = (currentSourcePosition % 4) + 1;
-        this.updateExecution({
+        return this.updateExecution({
           hdmiSource: 'input' + nextSourcePosition,
         });
-        break;
       }
     }
   }
 
   // An unknown current intensity falls back so the step still lands on a
   // valid value: stepping down assumes 'intense' (4), stepping up 'subtle' (1).
-  private stepIntensity(direction: -1 | 1): void {
+  private stepIntensity(direction: -1 | 1): Promise<void> | undefined {
     // Gets the current mode or the last sync mode to set the intensity
     const mode = this.getMode();
 
@@ -239,7 +228,7 @@ export abstract class BaseTvDevice extends SyncBoxDevice {
     if (!nextIntensity) {
       return;
     }
-    this.updateExecution({ [mode]: { intensity: nextIntensity } });
+    return this.updateExecution({ [mode]: { intensity: nextIntensity } });
   }
 
   protected updateSources(services: Service[]) {

--- a/src/accessories/entertainmentTv.ts
+++ b/src/accessories/entertainmentTv.ts
@@ -1,4 +1,5 @@
-import type { PlatformAccessory } from 'homebridge';
+import { HAPStatus, type PlatformAccessory } from 'homebridge';
+import { describeError } from '../lib/client.js';
 import type { HueSyncBoxPlatform } from '../platform.js';
 import type { State } from '../state.js';
 import { BaseTvDevice } from './baseTv.js';
@@ -24,14 +25,17 @@ export class EntertainmentTvDevice extends BaseTvDevice {
         }
         // Saves the changes
         this.platform.log.debug('Switch entertainment area to ' + group.name);
-        this.platform.client
+        return this.platform.client
           .updateHue({
             groupId: groupId,
           })
           .catch(e => {
             this.platform.log.error(
               'Failed to switch entertainment area to ' + group.name,
-              e
+              describeError(e)
+            );
+            throw new this.platform.api.hap.HapStatusError(
+              HAPStatus.SERVICE_COMMUNICATION_FAILURE
             );
           });
       });

--- a/src/accessories/intensityTv.ts
+++ b/src/accessories/intensityTv.ts
@@ -22,7 +22,7 @@ export class IntensityTvDevice extends BaseTvDevice {
         body[mode] = {
           intensity,
         };
-        this.updateExecution(body);
+        return this.updateExecution(body);
       });
   }
 

--- a/src/accessories/modeTv.ts
+++ b/src/accessories/modeTv.ts
@@ -20,7 +20,7 @@ export class ModeTvDevice extends BaseTvDevice {
       .onSet((value: CharacteristicValue) => {
         const mode = this.numberToMode.get(value as number);
         this.platform.log.debug('Switch mode to ' + mode);
-        this.updateExecution({
+        return this.updateExecution({
           mode,
         });
       });

--- a/src/api-server.ts
+++ b/src/api-server.ts
@@ -17,6 +17,7 @@ import {
   validateExecution,
   validateHue,
 } from './lib/validation.js';
+import { describeError } from './lib/client.js';
 
 export class ApiServer {
   private readonly platform: HueSyncBoxPlatform;
@@ -95,17 +96,34 @@ export class ApiServer {
             if (rejected) {
               return;
             }
-            switch (request.method) {
-              case 'GET':
-                await this.handleGet(response);
-                break;
-              case 'POST':
-                await this.handlePost(payload, response);
-                break;
-              default:
-                this.platform.log.debug('No action matched.');
-                response.statusCode = HTTP_STATUS_METHOD_NOT_ALLOWED;
-                response.end();
+            // This listener's promise is never observed, so an escaping
+            // rejection would be an unhandled rejection rather than a
+            // response the caller can act on.
+            try {
+              switch (request.method) {
+                case 'GET':
+                  await this.handleGet(response);
+                  break;
+                case 'POST':
+                  await this.handlePost(payload, response);
+                  break;
+                default:
+                  this.platform.log.debug('No action matched.');
+                  response.statusCode = HTTP_STATUS_METHOD_NOT_ALLOWED;
+                  response.end();
+              }
+            } catch (e) {
+              this.platform.log.error(
+                'Error while handling an API request.',
+                describeError(e)
+              );
+              if (!response.headersSent) {
+                this.sendError(
+                  response,
+                  HTTP_STATUS_INTERNAL_ERROR,
+                  'An error occurred while processing your request.'
+                );
+              }
             }
           });
       });

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -39,7 +39,7 @@ class SyncBoxResponseError extends Error {}
 // Homebridge prints a full stack when handed an Error. These failures all
 // unwind through node-fetch internals, so the stack costs a screen of log
 // and says nothing the message doesn't.
-function describeError(e: unknown): string {
+export function describeError(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
@@ -65,33 +65,22 @@ export class SyncBoxClient {
     return this.lock.acquire(this.LOCK_KEY, task, this.LOCK_OPTIONS);
   }
 
-  public async getState(): Promise<State | null> {
-    try {
-      return await this.withLock(() => this.sendRequest<State>('GET', ''));
-    } catch (e) {
-      // Polling retries on its own schedule, so a failed read is recoverable
-      // on the next tick rather than an error the user has to act on.
-      this.log.warn('Failed to get state from Sync Box:', describeError(e));
-      return null;
-    }
+  // These reject on failure. Callers decide what a failure means: polling
+  // logs and waits for the next tick, HomeKit surfaces it to the Home app,
+  // and the HTTP API answers with an error status. Resolving anyway would
+  // report a command as applied that the Sync Box never received.
+  public getState(): Promise<State> {
+    return this.withLock(() => this.sendRequest<State>('GET', ''));
   }
 
   public async updateExecution(execution: Partial<Execution>): Promise<void> {
-    try {
-      await this.withLock(() =>
-        this.sendRequest<void>('PUT', 'execution', execution)
-      );
-    } catch (e) {
-      this.log.error('Error updating execution:', describeError(e));
-    }
+    await this.withLock(() =>
+      this.sendRequest<void>('PUT', 'execution', execution)
+    );
   }
 
   public async updateHue(hue: Partial<Hue>): Promise<void> {
-    try {
-      await this.withLock(() => this.sendRequest<void>('PUT', 'hue', hue));
-    } catch (e) {
-      this.log.error('Error updating hue:', describeError(e));
-    }
+    await this.withLock(() => this.sendRequest<void>('PUT', 'hue', hue));
   }
 
   /**

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -7,7 +7,7 @@ import {
 } from 'homebridge';
 
 import type { HueSyncBoxPlatformConfig } from './config.js';
-import { SyncBoxClient } from './lib/client.js';
+import { describeError, SyncBoxClient } from './lib/client.js';
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
 import { State } from './state.js';
 import { SyncBoxDevice } from './accessories/base.js';
@@ -97,14 +97,17 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
 
     this.api.on('didFinishLaunching', async () => {
       this.log.debug('Executed didFinishLaunching callback');
-      // A rejection here would otherwise escape this async event listener as
-      // an unhandled rejection, which Homebridge treats as fatal to the
-      // entire process rather than just this plugin - the exact failure mode
-      // this class of fix is meant to close off.
+      // A rejection escaping this async event listener is an unhandled
+      // rejection, which Homebridge treats as fatal to the entire process
+      // rather than just this plugin.
       try {
         await this.discoverDevices();
       } catch (e) {
-        this.log.error('Failed to discover devices on startup.', e);
+        this.log.error(
+          'Failed to discover devices on startup. Ensure the Sync Box is online and the ' +
+            'API token is correct, then restart the plugin:',
+          describeError(e)
+        );
       }
     });
 
@@ -152,7 +155,7 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
 
   // Omits WiFi SSID and LAN IP addresses from debug output, since debug logs are
   // routinely pasted into public support requests/issues.
-  private redactStateForLogging(state: State): unknown {
+  private redactStateForLogging(state: State): State {
     return {
       ...state,
       device: {
@@ -174,12 +177,6 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
 
   async discoverDevices() {
     const state = await this.client.getState();
-    if (!state) {
-      throw new Error(
-        'Could not get state from sync box on initialization. This error is not recoverable, ' +
-          'ensure the sync box is online and the API token is correct and restart the plugin.'
-      );
-    }
     this.log.debug('Discovered state:', this.redactStateForLogging(state));
     const accessories = this.discoverAccessories(state);
     const uuids = accessories.map(accessory => {
@@ -258,6 +255,14 @@ export class HueSyncBoxPlatform implements DynamicPlatformPlugin {
       try {
         const state = await this.client.getState();
         await this.update(state);
+      } catch (e) {
+        // setInterval never observes this callback's promise, so an escaping
+        // rejection would take down the whole Homebridge process. A failed
+        // poll is recoverable on the next tick.
+        this.log.warn(
+          'Poll failed, retrying on the next tick:',
+          describeError(e)
+        );
       } finally {
         polling = false;
       }

--- a/test/unit/api-server.test.ts
+++ b/test/unit/api-server.test.ts
@@ -18,7 +18,26 @@ function makePlatform(config: Record<string, unknown>): HueSyncBoxPlatform {
 }
 
 function getServer(apiServer: ApiServer) {
-  return (apiServer as unknown as { server?: { close: () => void } }).server;
+  return (
+    apiServer as unknown as {
+      server?: import('http').Server;
+    }
+  ).server;
+}
+
+function apiServerInternals(apiServer: ApiServer) {
+  return apiServer as unknown as Record<string, unknown>;
+}
+
+function makeResponse() {
+  return {
+    statusCode: 200,
+    body: '',
+    setHeader: vi.fn(),
+    end(body?: string) {
+      this.body = body ?? '';
+    },
+  };
 }
 
 describe('ApiServer.start', () => {
@@ -86,4 +105,28 @@ describe('ApiServer.start', () => {
       getServer(serverB)?.close();
     }
   }, 10000);
+});
+
+describe('ApiServer request handling', () => {
+  it('answers with an error status when the Sync Box read fails', async () => {
+    const platform = makePlatform({
+      apiServerPort: 40296,
+      apiServerToken: VALID_TOKEN,
+    });
+    platform.client.getState = vi
+      .fn()
+      .mockRejectedValue(new Error('ECONNREFUSED'));
+    const response = makeResponse();
+
+    await (
+      apiServerInternals(new ApiServer(platform)) as {
+        handleGet(response: unknown): Promise<void>;
+      }
+    ).handleGet(response);
+
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body)).toEqual({
+      error: 'An error occurred while processing your request.',
+    });
+  });
 });

--- a/test/unit/lib/client.test.ts
+++ b/test/unit/lib/client.test.ts
@@ -210,16 +210,13 @@ describe('SyncBoxClient', () => {
       const log = makeLog();
       const client = new SyncBoxClient(log, makeConfig());
 
-      const resultPromise = client.getState();
-      await vi.advanceTimersByTimeAsync(HTTP_RETRY_BASE_DELAY_MS * 4);
-      const result = await resultPromise;
-
-      expect(result).toBeNull();
-      expect(mockFetch.mock.calls.length).toBeLessThan(4);
-      expect(log.warn).toHaveBeenCalledWith(
-        'Failed to get state from Sync Box:',
+      const rejects = expect(client.getState()).rejects.toThrow(
         'The operation was aborted.'
       );
+      await vi.advanceTimersByTimeAsync(HTTP_RETRY_BASE_DELAY_MS * 4);
+      await rejects;
+
+      expect(mockFetch.mock.calls.length).toBeLessThan(4);
     } finally {
       vi.useRealTimers();
     }
@@ -255,12 +252,11 @@ describe('SyncBoxClient', () => {
       const log = makeLog();
       const client = new SyncBoxClient(log, makeConfig());
 
-      const resultPromise = client.getState();
+      const rejects = expect(client.getState()).rejects.toThrow('ECONNREFUSED');
       // Cumulative backoff for HTTP_RETRY_COUNT retries: 1000+2000+4000=7000ms.
       await vi.advanceTimersByTimeAsync(7000);
-      const result = await resultPromise;
+      await rejects;
 
-      expect(result).toBeNull();
       expect(mockFetch).toHaveBeenCalledTimes(4);
     } finally {
       vi.useRealTimers();
@@ -274,14 +270,11 @@ describe('SyncBoxClient', () => {
     const log = makeLog();
     const client = new SyncBoxClient(log, makeConfig());
 
-    const result = await client.getState();
-
-    expect(result).toBeNull();
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(log.warn).toHaveBeenCalledWith(
-      'Failed to get state from Sync Box:',
+    await expect(client.getState()).rejects.toThrow(
       'Error: 500 - Internal Server Error'
     );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a malformed state response without retrying it', async () => {
@@ -289,14 +282,11 @@ describe('SyncBoxClient', () => {
     const log = makeLog();
     const client = new SyncBoxClient(log, makeConfig());
 
-    const result = await client.getState();
-
-    expect(result).toBeNull();
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(log.warn).toHaveBeenCalledWith(
-      'Failed to get state from Sync Box:',
+    await expect(client.getState()).rejects.toThrow(
       'Sync Box returned a malformed state response.'
     );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('returns the parsed state on success', async () => {

--- a/test/unit/platform.test.ts
+++ b/test/unit/platform.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { HueSyncBoxPlatform } from '../../src/platform.js';
 import type { API, Logging, PlatformConfig } from 'homebridge';
+import type { State } from '../../src/state.js';
 
 function makeApi(): API {
   return {
@@ -39,6 +40,10 @@ function makeConfig(): PlatformConfig {
 }
 
 type PollingPlatform = HueSyncBoxPlatform & { schedulePolling(): void };
+
+function makeState(): State {
+  return { execution: { mode: 'video' } } as unknown as State;
+}
 
 describe('HueSyncBoxPlatform polling', () => {
   beforeEach(() => {
@@ -86,5 +91,35 @@ describe('HueSyncBoxPlatform polling', () => {
 
     expect(getState).toHaveBeenCalledTimes(2);
     expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps polling after a failed tick instead of rejecting into the process', async () => {
+    const platform = new HueSyncBoxPlatform(makeLog(), makeConfig(), makeApi());
+    const getState = vi
+      .spyOn(platform.client, 'getState')
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValue(makeState());
+    const update = vi.spyOn(platform, 'update').mockResolvedValue(undefined);
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+
+    try {
+      (platform as PollingPlatform).schedulePolling();
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(getState).toHaveBeenCalledTimes(1);
+      expect(update).not.toHaveBeenCalled();
+      expect(platform.log.warn).toHaveBeenCalledWith(
+        'Poll failed, retrying on the next tick:',
+        'ECONNREFUSED'
+      );
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(getState).toHaveBeenCalledTimes(2);
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+    }
   });
 });


### PR DESCRIPTION
Non-breaking half of #472, split out per request.

## Failures were reported as success

`SyncBoxClient` swallowed every transport, timeout, and validation failure: `getState()` returned `null` and the update methods resolved anyway. Callers could not distinguish a failed command from an applied one.

- `GET /state` answered `200` with a `null` body when the box was unreachable
- `POST /state` answered `200` after a write that never landed
- HomeKit `onSet` handlers resolved, so the Home app showed state the Sync Box never accepted

The client now rejects, and each caller decides what a failure means:

| Caller | Behavior |
| --- | --- |
| Polling | Logs and retries on the next tick, inside a catch that stops an escaping rejection from killing the Homebridge process |
| Accessories | Return their promise and rethrow `HapStatusError(SERVICE_COMMUNICATION_FAILURE)` so Home shows the failure |
| HTTP API | Answers with an error status; the request handler is wrapped so it can no longer reject unobserved |

No config or default changes here — the API-bind hardening and HTTPS support (the breaking parts) are split into a follow-up PR stacked on this branch.

## Verification

- `npm test` — 97 passed, incl. new: poll survives a failed tick, API answers an error status when the read fails
- 4 existing client tests updated from "resolves null" to "rejects"
- `npm run tsc`, `npm run lint`, `npm run build` clean

Accessory changes are `return` statements plus one rethrow; `src/accessories/` has no test coverage, verified by type-check and review.
